### PR TITLE
Setup: Configure CI to only run on pull requests

### DIFF
--- a/.github/workflows/ci-checklist.yml
+++ b/.github/workflows/ci-checklist.yml
@@ -171,7 +171,8 @@ jobs:
   typecheck-backend:
     name: ✅ Type Check Backend (mypy)
     runs-on: ubuntu-latest
-    needs: install-backend
+    needs: [install-backend, detect-changes]
+    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.workflow-only != 'true'
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
## Changes
- Remove push trigger from CI workflow
- CI now only runs on pull request events (opened, synchronize, reopened)
- Prevents CI cycles from running after merging to master/main

## Why
- Reduces unnecessary CI runs
- CI should validate PRs, not merged code
- Deployment workflow handles post-merge actions