### PR TITLE
feat: Add historical rollout viewing with S3 storage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,9 @@ lens-ai-*.json
 .env.test
 !.env.example
 !backend/.env.example
+
+# Token files (never commit)
+**/tokens/*.txt
+**/tokens/dev.txt
+**/tokens/prod.txt
+backend/tokens/

--- a/app/components/GridCanvasThree.tsx
+++ b/app/components/GridCanvasThree.tsx
@@ -379,6 +379,11 @@ function SceneContentInner({
   const height = world.height
   const cellSize = world.cellSize || 1
 
+  // Debug: Log when dimensions change
+  useEffect(() => {
+    console.log('📐 Grid dimensions changed:', { width, height, cellSize })
+  }, [width, height, cellSize])
+
   const cells = useMemo(() => {
     if (!envSpec) {
       return []
@@ -492,13 +497,13 @@ function SceneContentInner({
       <pointLight position={[-10, 10, -10]} intensity={0.7} color="#ffffff" />
 
       {/* Manual grid lines - VERY VISIBLE using thick boxes - aligned with cell edges */}
-      <group position={[0, 0.06, 0]}>
+      <group position={[0, 0.06, 0]} key={`grid-lines-${width}-${height}`}>
         {/* Vertical lines - positioned at cell boundaries */}
         {Array.from({ length: width + 1 }, (_, i) => {
           // Lines at: -width/2, -width/2+1, ..., width/2
           const x = i - width / 2
           return (
-            <mesh key={`v-${i}`} position={[x, 0, 0]}>
+            <mesh key={`v-${width}-${height}-${i}`} position={[x, 0, 0]}>
               <boxGeometry args={[0.02, 0.02, height]} />
               <meshStandardMaterial color="#475569" />
             </mesh>
@@ -509,7 +514,7 @@ function SceneContentInner({
           // Lines at: -height/2, -height/2+1, ..., height/2
           const z = i - height / 2
           return (
-            <mesh key={`h-${i}`} position={[0, 0, z]}>
+            <mesh key={`h-${width}-${height}-${i}`} position={[0, 0, z]}>
               <boxGeometry args={[width, 0.02, 0.02]} />
               <meshStandardMaterial color="#475569" />
             </mesh>
@@ -521,7 +526,12 @@ function SceneContentInner({
       {cells}
 
       {/* Ground plane - positioned below grid cells */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.15, 0]} receiveShadow>
+      <mesh 
+        key={`ground-${width}-${height}`}
+        rotation={[-Math.PI / 2, 0, 0]} 
+        position={[0, -0.15, 0]} 
+        receiveShadow
+      >
         <planeGeometry args={[width + 4, height + 4]} />
         <meshStandardMaterial color="#e2e8f0" />
       </mesh>
@@ -529,7 +539,8 @@ function SceneContentInner({
   )
 }
 
-const SceneContent = memo(SceneContentInner)
+// Remove memo to ensure updates work - key-based remounting handles performance
+const SceneContent = SceneContentInner
 
 export function GridCanvasThree({
   envSpec,
@@ -653,6 +664,17 @@ export function GridCanvasThree({
   const width = world.width
   const height = world.height
   const cellSize = world.cellSize || 1
+
+  // Debug: Log when envSpec world dimensions change
+  useEffect(() => {
+    console.log('🔍 GridCanvasThree - World dimensions:', { 
+      width, 
+      height, 
+      cellSize,
+      worldWidth: world.width,
+      worldHeight: world.height
+    })
+  }, [width, height, cellSize, world.width, world.height])
 
   // Convert grid position to world coordinates
   const gridToWorld = (gridX: number, gridY: number): Vec2 => {
@@ -1041,6 +1063,7 @@ export function GridCanvasThree({
           />
 
           <SceneContent
+            key={`grid-${width}-${height}`}
             envSpec={envSpec}
             rolloutState={rolloutState}
             onCellClick={handleCellClick}

--- a/app/components/GridCanvasThree.tsx
+++ b/app/components/GridCanvasThree.tsx
@@ -427,24 +427,28 @@ function SceneContentInner({
         if (!agent || !agent.position || !Array.isArray(agent.position)) continue
         const [agentX, agentY] = agent.position
 
-        // Convert agent world position to grid coordinates
-        const agentGridX = Math.round(agentX / cellSize) // Use round instead of floor for better matching
-        const agentGridY = Math.round(agentY / cellSize)
+        // For grid environments, positions are already in grid coordinates (integers)
+        // For continuous environments, we need to convert world to grid
+        const isGrid = envSpec?.world?.coordinateSystem === 'grid'
+        const agentGridX = isGrid ? Math.round(agentX) : Math.round(agentX / cellSize)
+        const agentGridY = isGrid ? Math.round(agentY) : Math.round(agentY / cellSize)
 
         // Exact grid match
         if (agentGridX === gridX && agentGridY === gridY) {
           return agent
         }
 
-        // Tolerance check (for floating point precision)
-        const cellWorldX = worldPos[0]
-        const cellWorldY = worldPos[1]
-        const tolerance = cellSize * 0.6 // Increased tolerance
-        if (
-          Math.abs(agentX - cellWorldX) < tolerance &&
-          Math.abs(agentY - cellWorldY) < tolerance
-        ) {
-          return agent
+        // Tolerance check (for floating point precision in continuous mode)
+        if (!isGrid) {
+          const cellWorldX = worldPos[0]
+          const cellWorldY = worldPos[1]
+          const tolerance = cellSize * 0.6
+          if (
+            Math.abs(agentX - cellWorldX) < tolerance &&
+            Math.abs(agentY - cellWorldY) < tolerance
+          ) {
+            return agent
+          }
         }
       }
 
@@ -713,21 +717,25 @@ export function GridCanvasThree({
       if (!agent || !agent.position || !Array.isArray(agent.position)) continue
       const [agentX, agentY] = agent.position
 
-      // Convert agent world position to grid coordinates (use round for better matching)
-      const agentGridX = Math.round(agentX / cellSize)
-      const agentGridY = Math.round(agentY / cellSize)
+      // For grid environments, positions are already in grid coordinates (integers)
+      // For continuous environments, we need to convert world to grid
+      const isGrid = envSpec?.world?.coordinateSystem === 'grid'
+      const agentGridX = isGrid ? Math.round(agentX) : Math.round(agentX / cellSize)
+      const agentGridY = isGrid ? Math.round(agentY) : Math.round(agentY / cellSize)
 
       // Exact grid match
       if (agentGridX === gridX && agentGridY === gridY) {
         return agent
       }
 
-      // Tolerance check (for floating point precision)
-      const cellWorldX = worldPos[0]
-      const cellWorldY = worldPos[1]
-      const tolerance = cellSize * 0.6 // Increased tolerance
-      if (Math.abs(agentX - cellWorldX) < tolerance && Math.abs(agentY - cellWorldY) < tolerance) {
-        return agent
+      // Tolerance check (for floating point precision in continuous mode)
+      if (!isGrid) {
+        const cellWorldX = worldPos[0]
+        const cellWorldY = worldPos[1]
+        const tolerance = cellSize * 0.6
+        if (Math.abs(agentX - cellWorldX) < tolerance && Math.abs(agentY - cellWorldY) < tolerance) {
+          return agent
+        }
       }
     }
 

--- a/app/components/PolicyEntropyChart.tsx
+++ b/app/components/PolicyEntropyChart.tsx
@@ -1,7 +1,6 @@
 /**
  * Policy Entropy Over Time Component
- * REQUIRES Python backend - NO FALLBACKS
- * Real calculations use scipy.stats.entropy in backend
+ * Clean professional visualization of policy entropy
  */
 
 import { useEffect, useState } from 'react'
@@ -14,6 +13,7 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  ReferenceLine,
 } from 'recharts'
 import { EnvSpec } from '~/lib/envSpec'
 
@@ -33,35 +33,22 @@ export function PolicyEntropyChart({ rollouts, envSpec }: PolicyEntropyChartProp
   const [entropyData, setEntropyData] = useState<Array<{ step: number; entropy: number }>>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [progress, setProgress] = useState<{
-    current: number
-    total: number
-    message: string
-  } | null>(null)
 
   useEffect(() => {
     if (rollouts.length === 0) return
 
     setLoading(true)
     setError(null)
-    setProgress(null)
 
-    // Analyze all rollouts using streaming (real Python calculations)
     const analyses: Array<{ step: number; entropy: number }> = []
     let completed = 0
     const total = rollouts.length
 
     rollouts.forEach((rolloutSteps, idx) => {
-      const cleanup = analyzeTrajectoryStreaming(
+      analyzeTrajectoryStreaming(
         { rollout_steps: rolloutSteps, env_spec: envSpec },
         {
-          onProgress: (prog, msg) => {
-            setProgress({
-              current: completed,
-              total,
-              message: `Analyzing rollout ${idx + 1}/${total}: ${msg}`,
-            })
-          },
+          onProgress: () => {},
           onComplete: (analysis: TrajectoryAnalysis) => {
             analyses.push({
               step: idx + 1,
@@ -70,27 +57,14 @@ export function PolicyEntropyChart({ rollouts, envSpec }: PolicyEntropyChartProp
             completed++
 
             if (completed === total) {
-              // Sort by step
               analyses.sort((a, b) => a.step - b.step)
               setEntropyData(analyses)
               setLoading(false)
-              setProgress(null)
-              console.log(
-                '✅ Policy entropy analysis complete - Real Python calculations (scipy.stats.entropy)'
-              )
-            } else {
-              setProgress({
-                current: completed,
-                total,
-                message: `Completed ${completed}/${total} rollouts...`,
-              })
             }
           },
           onError: (err) => {
             setError(err.message)
             setLoading(false)
-            setProgress(null)
-            console.error('❌ Policy entropy analysis failed:', err)
           },
         }
       )
@@ -99,188 +73,104 @@ export function PolicyEntropyChart({ rollouts, envSpec }: PolicyEntropyChartProp
 
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
-        <div className="text-sm mb-2">Running Python analysis (scipy.stats.entropy)...</div>
-        {progress && (
-          <div className="text-xs text-muted-foreground">
-            {progress.message} ({progress.current}/{progress.total})
-          </div>
-        )}
-        <div className="mt-4 w-64 h-2 bg-muted rounded-full overflow-hidden">
-          <div
-            className="h-full bg-primary transition-all duration-300"
-            style={{ width: `${progress ? (progress.current / progress.total) * 100 : 0}%` }}
-          />
-        </div>
+      <div className="flex items-center justify-center h-48">
+        <div className="text-sm text-muted-foreground">Analyzing entropy...</div>
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 text-destructive border border-destructive/50 rounded-lg p-4 bg-destructive/10">
-        <div className="font-semibold mb-2">❌ Backend Required</div>
-        <div className="text-sm text-center">{error}</div>
-        <div className="text-xs mt-2 text-muted-foreground">
-          Real Python calculations (scipy.stats.entropy) are required. Backend:{' '}
-          <code className="bg-muted px-1 rounded">
-            {import.meta.env.VITE_ROLLOUT_SERVICE_URL || 'http://localhost:8000'}
-          </code>
-        </div>
+      <div className="flex items-center justify-center h-48">
+        <div className="text-sm text-red-600">{error}</div>
       </div>
     )
   }
 
   if (entropyData.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64 text-muted-foreground">
-        No entropy data available. Run multiple rollouts to see policy entropy over time.
+      <div className="flex items-center justify-center h-48">
+        <div className="text-sm text-muted-foreground">
+          Run multiple rollouts to see entropy analysis
+        </div>
       </div>
     )
   }
 
-  // Calculate statistics
   const meanEntropy = entropyData.reduce((sum, d) => sum + d.entropy, 0) / entropyData.length
   const minEntropy = Math.min(...entropyData.map((d) => d.entropy))
   const maxEntropy = Math.max(...entropyData.map((d) => d.entropy))
-  const stdEntropy = Math.sqrt(
-    entropyData.reduce((sum, d) => sum + Math.pow(d.entropy - meanEntropy, 2), 0) /
-      entropyData.length
-  )
 
   return (
-    <div className="space-y-5">
-      {/* Professional Header */}
-      <div className="flex items-center justify-between pb-3 border-b border-border">
-        <div>
-          <h3 className="text-xl font-bold text-foreground">Policy Entropy Analysis</h3>
-          <p className="text-xs text-muted-foreground mt-1">
-            Shannon entropy (base 2) over rollouts
-          </p>
+    <div className="space-y-4">
+      {/* Stats */}
+      <div className="grid grid-cols-4 gap-3">
+        <div className="border border-border rounded p-2">
+          <div className="text-xs text-muted-foreground">Rollouts</div>
+          <div className="text-lg font-mono font-semibold">{rollouts.length}</div>
         </div>
-        <div className="text-right">
-          <div className="text-sm font-semibold text-foreground">{rollouts.length} rollouts</div>
-          <div className="text-xs text-muted-foreground">μ = {meanEntropy.toFixed(3)} bits</div>
-          <div className="text-xs text-green-600 font-mono mt-1">✓ scipy.stats.entropy</div>
+        <div className="border border-border rounded p-2">
+          <div className="text-xs text-muted-foreground">Mean</div>
+          <div className="text-lg font-mono font-semibold">{meanEntropy.toFixed(3)}</div>
         </div>
-      </div>
-
-      {/* Professional Statistics Cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <div className="bg-card p-4 rounded-lg border border-border shadow-sm">
-          <div className="text-xs text-muted-foreground mb-1">Mean (μ)</div>
-          <div className="text-2xl font-bold text-foreground">{meanEntropy.toFixed(3)}</div>
-          <div className="text-[10px] text-muted-foreground font-mono mt-1">bits</div>
+        <div className="border border-border rounded p-2">
+          <div className="text-xs text-muted-foreground">Min</div>
+          <div className="text-lg font-mono font-semibold">{minEntropy.toFixed(3)}</div>
         </div>
-        <div className="bg-card p-4 rounded-lg border border-border shadow-sm">
-          <div className="text-xs text-muted-foreground mb-1">Std Dev (σ)</div>
-          <div className="text-2xl font-bold text-foreground">{stdEntropy.toFixed(3)}</div>
-          <div className="text-[10px] text-muted-foreground font-mono mt-1">bits</div>
-        </div>
-        <div className="bg-card p-4 rounded-lg border border-border shadow-sm">
-          <div className="text-xs text-muted-foreground mb-1">Minimum</div>
-          <div className="text-2xl font-bold text-foreground">{minEntropy.toFixed(3)}</div>
-          <div className="text-[10px] text-muted-foreground font-mono mt-1">bits</div>
-        </div>
-        <div className="bg-card p-4 rounded-lg border border-border shadow-sm">
-          <div className="text-xs text-muted-foreground mb-1">Maximum</div>
-          <div className="text-2xl font-bold text-foreground">{maxEntropy.toFixed(3)}</div>
-          <div className="text-[10px] text-muted-foreground font-mono mt-1">bits</div>
+        <div className="border border-border rounded p-2">
+          <div className="text-xs text-muted-foreground">Max</div>
+          <div className="text-lg font-mono font-semibold">{maxEntropy.toFixed(3)}</div>
         </div>
       </div>
 
-      {/* Professional Line Chart */}
-      <div className="bg-card border border-border rounded-lg p-5 shadow-sm">
-        <div className="flex items-center justify-between mb-4">
-          <h4 className="text-md font-bold text-foreground">Entropy Over Rollouts</h4>
-          <span className="text-xs text-muted-foreground font-mono">
-            H(policy) = -Σ p(a) log₂ p(a)
-          </span>
-        </div>
-        <ResponsiveContainer width="100%" height={320}>
-          <LineChart data={entropyData} margin={{ top: 10, right: 10, left: 10, bottom: 10 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--muted-foreground) / 0.15)" />
-            <XAxis
-              dataKey="step"
-              stroke="hsl(var(--muted-foreground))"
-              tick={{ fontSize: 11 }}
-              label={{
-                value: 'Rollout Number',
-                position: 'insideBottom',
-                offset: -5,
-                style: { fontSize: 12 },
-              }}
-            />
-            <YAxis
-              stroke="hsl(var(--muted-foreground))"
-              tick={{ fontSize: 11 }}
-              label={{
-                value: 'Entropy (bits)',
-                angle: -90,
-                position: 'insideLeft',
-                style: { fontSize: 12 },
-              }}
-              domain={[0, Math.max(maxEntropy * 1.1, 2)]}
-            />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: 'hsl(var(--card))',
-                border: '1px solid hsl(var(--border))',
-                borderRadius: '6px',
-                boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
-              }}
-              labelStyle={{
-                color: 'hsl(var(--foreground))',
-                fontWeight: 'bold',
-                marginBottom: '4px',
-              }}
-              itemStyle={{ color: 'hsl(var(--foreground))' }}
-              formatter={(value: number) => [`${value.toFixed(3)} bits`, 'Entropy']}
-            />
-            <Line
-              type="monotone"
-              dataKey="entropy"
-              stroke="hsl(var(--primary))"
-              strokeWidth={3}
-              dot={{ r: 4, fill: 'hsl(var(--primary))' }}
-              activeDot={{ r: 6 }}
-              name="Policy Entropy"
-            />
-            {/* Mean reference line */}
-            <Line
-              type="monotone"
-              dataKey={() => meanEntropy}
-              stroke="hsl(var(--muted-foreground))"
-              strokeWidth={1.5}
-              strokeDasharray="5 5"
-              dot={false}
-              name="Mean"
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
+      {/* Chart */}
+      <ResponsiveContainer width="100%" height={250}>
+        <LineChart data={entropyData} margin={{ top: 10, right: 20, left: 10, bottom: 10 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" opacity={0.5} />
+          <XAxis
+            dataKey="step"
+            stroke="hsl(var(--muted-foreground))"
+            fontSize={11}
+            tickLine={false}
+            label={{ value: 'Rollout', position: 'insideBottom', offset: -5, fontSize: 11 }}
+          />
+          <YAxis
+            stroke="hsl(var(--muted-foreground))"
+            fontSize={11}
+            tickLine={false}
+            domain={[0, Math.max(maxEntropy * 1.1, 2)]}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'hsl(var(--popover))',
+              border: '1px solid hsl(var(--border))',
+              borderRadius: '6px',
+              fontSize: '12px',
+            }}
+            formatter={(value: number) => [`${value.toFixed(3)} bits`, 'Entropy']}
+          />
+          <ReferenceLine
+            y={meanEntropy}
+            stroke="hsl(var(--muted-foreground))"
+            strokeDasharray="3 3"
+            opacity={0.5}
+          />
+          <Line
+            type="monotone"
+            dataKey="entropy"
+            stroke="#6366f1"
+            strokeWidth={2}
+            dot={{ r: 3, fill: '#6366f1' }}
+            activeDot={{ r: 5 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
 
       {/* Interpretation */}
-      <div className="bg-muted/20 border border-border rounded-md p-3 text-sm">
-        <div className="font-semibold mb-2">
-          Interpretation (calculated with scipy.stats.entropy):
-        </div>
-        <ul className="list-disc list-inside space-y-1 text-muted-foreground">
-          <li>
-            <strong>High entropy</strong> ({meanEntropy > 1.5 ? 'current' : 'typically'} &gt; 1.5):
-            Policy is exploring, actions are diverse
-          </li>
-          <li>
-            <strong>Low entropy</strong> ({meanEntropy < 0.5 ? 'current' : 'typically'} &lt; 0.5):
-            Policy is exploiting, actions are deterministic
-          </li>
-          <li>
-            <strong>Decreasing entropy</strong>: Policy is converging, becoming more deterministic
-          </li>
-          <li>
-            <strong>Increasing entropy</strong>: Policy is exploring more, becoming more random
-          </li>
-        </ul>
+      <div className="text-xs text-muted-foreground">
+        <p>
+          <strong>High entropy (&gt;1.5):</strong> Exploring, diverse actions. <strong>Low entropy (&lt;0.5):</strong> Exploiting, deterministic.
+        </p>
       </div>
     </div>
   )

--- a/app/components/RLAnalysisTab.tsx
+++ b/app/components/RLAnalysisTab.tsx
@@ -1,0 +1,489 @@
+/**
+ * RL Analysis Tab Component
+ * Clean, professional UI for scientific analysis of rollout data
+ */
+
+import { useMemo } from 'react'
+import { EnvSpec } from '~/lib/envSpec'
+import { RewardDecompositionHeatmap } from './RewardDecompositionHeatmap'
+import { TrajectoryPathVisualizer } from './TrajectoryPathVisualizer'
+import { PolicyEntropyChart } from './PolicyEntropyChart'
+import { TerminationAnalysisChart } from './TerminationAnalysisChart'
+import type { SimulatorResult } from '~/lib/universalSimulator'
+
+interface RLAnalysisTabProps {
+  rolloutResult: SimulatorResult | null
+  rolloutHistory?: Array<{
+    result: any
+    policy: string
+    _metadata?: { hasFullData?: boolean; totalSteps?: number }
+  }>
+  recentRolloutsWithData?: SimulatorResult[] // Recent rollouts with full step data
+  envSpec: EnvSpec
+  policy?: string
+}
+
+export function RLAnalysisTab({
+  rolloutResult,
+  rolloutHistory: _rolloutHistory,
+  recentRolloutsWithData = [],
+  envSpec,
+  policy = 'random',
+}: RLAnalysisTabProps) {
+  // Calculate stats from rollout
+  const stats = useMemo(() => {
+    if (!rolloutResult || !rolloutResult.steps || rolloutResult.steps.length === 0) {
+      return null
+    }
+
+    const steps = rolloutResult.steps
+    const rewards = steps.map((s) => s.reward || 0)
+    const actions = steps.map((s) => s.action).filter(Boolean)
+
+    // Action distribution
+    const actionCounts: Record<string, number> = {}
+    actions.forEach((action) => {
+      const actionStr = typeof action === 'string' ? action : JSON.stringify(action)
+      actionCounts[actionStr] = (actionCounts[actionStr] || 0) + 1
+    })
+
+    // Path efficiency
+    let pathEfficiency = 0
+    if (steps.length > 0 && steps[0].state?.agents?.[0]?.position) {
+      const startPos = steps[0].state.agents[0].position
+      const endPos = steps[steps.length - 1].state.agents[0].position
+      if (startPos && endPos) {
+        const straightLineDist = Math.sqrt(
+          Math.pow(endPos[0] - startPos[0], 2) + Math.pow(endPos[1] - startPos[1], 2)
+        )
+        pathEfficiency = straightLineDist > 0 ? (straightLineDist / steps.length) * 100 : 0
+      }
+    }
+
+    // Reward stats
+    const positiveRewards = rewards.filter((r) => r > 0)
+    const negativeRewards = rewards.filter((r) => r < 0)
+    const avgStepReward = rewards.reduce((a, b) => a + b, 0) / rewards.length
+
+    // Oscillations
+    const positions = steps
+      .map((s) => s.state?.agents?.[0]?.position)
+      .filter((p) => p && Array.isArray(p))
+    const uniquePositions = new Set(positions.map((p) => `${p[0]},${p[1]}`))
+    const oscillationRate = positions.length > 0 ? 1 - uniquePositions.size / positions.length : 0
+
+    return {
+      totalReward: rolloutResult.totalReward,
+      episodeLength: rolloutResult.episodeLength,
+      success: rolloutResult.success,
+      terminationReason: rolloutResult.terminationReason,
+      avgStepReward,
+      positiveRewardCount: positiveRewards.length,
+      negativeRewardCount: negativeRewards.length,
+      maxReward: rewards.length > 0 ? Math.max(...rewards) : 0,
+      minReward: rewards.length > 0 ? Math.min(...rewards) : 0,
+      actionDistribution: actionCounts,
+      pathEfficiency,
+      oscillationRate,
+      uniquePositions: uniquePositions.size,
+      totalPositions: positions.length,
+    }
+  }, [rolloutResult])
+
+  // Generate insights
+  const insights = useMemo(() => {
+    if (!stats) return []
+    const items: Array<{ type: 'success' | 'warning' | 'info'; text: string }> = []
+
+    if (stats.success) {
+      items.push({ type: 'success', text: `Goal reached in ${stats.episodeLength} steps` })
+    } else {
+      items.push({ type: 'warning', text: `Episode ended: ${stats.terminationReason || 'timeout'}` })
+    }
+
+    if (stats.pathEfficiency < 20) {
+      items.push({ type: 'warning', text: `Low path efficiency (${stats.pathEfficiency.toFixed(1)}%)` })
+    }
+
+    if (stats.oscillationRate > 0.3) {
+      items.push({ type: 'warning', text: `High oscillation rate (${(stats.oscillationRate * 100).toFixed(0)}%)` })
+    }
+
+    return items
+  }, [stats])
+
+  if (!rolloutResult) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center max-w-sm">
+          <p className="text-muted-foreground mb-2">No rollout data available</p>
+          <p className="text-xs text-muted-foreground">
+            Run a rollout from the Rollout Preview tab to see analysis
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-4 space-y-6 max-w-6xl mx-auto">
+        {/* Episode Summary */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold">Episode Summary</h2>
+            <span className="text-xs text-muted-foreground capitalize">Policy: {policy}</span>
+          </div>
+
+          {/* Key Metrics */}
+          <div className="grid grid-cols-3 md:grid-cols-6 gap-3 mb-4">
+            <MetricCard
+              label="Total Reward"
+              value={stats?.totalReward.toFixed(2) || '0'}
+              positive={stats ? stats.totalReward >= 0 : true}
+            />
+            <MetricCard label="Episode Length" value={String(stats?.episodeLength || 0)} unit="steps" />
+            <MetricCard
+              label="Success"
+              value={stats?.success ? '✓' : '✗'}
+              positive={stats?.success}
+            />
+            <MetricCard
+              label="Avg Reward/Step"
+              value={stats?.avgStepReward.toFixed(4) || '0'}
+              positive={stats ? stats.avgStepReward >= 0 : true}
+            />
+            <MetricCard
+              label="Path Efficiency"
+              value={`${stats?.pathEfficiency.toFixed(1) || 0}%`}
+            />
+            <MetricCard
+              label="Unique Positions"
+              value={`${stats?.uniquePositions || 0}/${stats?.totalPositions || 0}`}
+            />
+          </div>
+
+          {/* Insights */}
+          {insights.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {insights.map((insight, i) => (
+                <span
+                  key={i}
+                  className={`text-xs px-2 py-1 rounded ${
+                    insight.type === 'success'
+                      ? 'bg-green-500/10 text-green-700 dark:text-green-400'
+                      : insight.type === 'warning'
+                        ? 'bg-amber-500/10 text-amber-700 dark:text-amber-400'
+                        : 'bg-blue-500/10 text-blue-700 dark:text-blue-400'
+                  }`}
+                >
+                  {insight.text}
+                </span>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Action Distribution */}
+        {stats && Object.keys(stats.actionDistribution).length > 0 && (
+          <section>
+            <h3 className="text-sm font-medium mb-3">Action Distribution</h3>
+            <div className="border border-border rounded-lg overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50">
+                  <tr>
+                    <th className="text-left px-3 py-2 font-medium">Action</th>
+                    <th className="text-right px-3 py-2 font-medium">Count</th>
+                    <th className="text-right px-3 py-2 font-medium">%</th>
+                    <th className="px-3 py-2 w-32"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(stats.actionDistribution)
+                    .sort(([, a], [, b]) => b - a)
+                    .map(([action, count]) => {
+                      const pct = (count / stats.episodeLength) * 100
+                      return (
+                        <tr key={action} className="border-t border-border">
+                          <td className="px-3 py-2 font-mono text-xs">{action}</td>
+                          <td className="px-3 py-2 text-right font-mono">{count}</td>
+                          <td className="px-3 py-2 text-right font-mono">{pct.toFixed(1)}%</td>
+                          <td className="px-3 py-2">
+                            <div className="h-2 bg-muted rounded-full overflow-hidden">
+                              <div
+                                className="h-full bg-foreground/20"
+                                style={{ width: `${pct}%` }}
+                              />
+                            </div>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Reward Analysis */}
+        <section>
+          <h3 className="text-sm font-medium mb-3">Reward Analysis</h3>
+          <div className="border border-border rounded-lg p-4">
+            <RewardDecompositionHeatmap rolloutSteps={rolloutResult.steps} envSpec={envSpec} />
+          </div>
+        </section>
+
+        {/* Trajectory Analysis */}
+        <section>
+          <h3 className="text-sm font-medium mb-3">Trajectory Analysis</h3>
+          <div className="border border-border rounded-lg p-4">
+            <TrajectoryPathVisualizer rolloutSteps={rolloutResult.steps} envSpec={envSpec} />
+          </div>
+        </section>
+
+        {/* Policy Entropy (Multiple Rollouts) */}
+        {recentRolloutsWithData.length > 0 && (
+          <section>
+            <h3 className="text-sm font-medium mb-3">Policy Entropy Over Time</h3>
+            <p className="text-xs text-muted-foreground mb-3">
+              Analyzing {recentRolloutsWithData.length} recent rollout{recentRolloutsWithData.length !== 1 ? 's' : ''} with full step data
+            </p>
+            <div className="border border-border rounded-lg p-4">
+              <PolicyEntropyChart
+                rollouts={recentRolloutsWithData
+                  .filter((r) => r && r.steps && r.steps.length > 0)
+                  .map((r) =>
+                    r.steps
+                      .filter((s: any) => s && s.state && s.action !== undefined)
+                      .map((s: any) => ({
+                        state: s.state || {},
+                        action: s.action,
+                        reward: s.reward || 0,
+                        done: s.done || false,
+                      }))
+                  )
+                  .filter((rollout) => rollout.length > 0)}
+                envSpec={envSpec}
+              />
+            </div>
+          </section>
+        )}
+
+        {/* Termination Analysis (Multiple Rollouts) */}
+        {recentRolloutsWithData.length > 1 && (
+          <section>
+            <h3 className="text-sm font-medium mb-3">Termination Analysis</h3>
+            <p className="text-xs text-muted-foreground mb-3">
+              Analyzing {recentRolloutsWithData.length} recent rollout{recentRolloutsWithData.length !== 1 ? 's' : ''} for termination patterns
+            </p>
+            <div className="border border-border rounded-lg p-4">
+              <TerminationAnalysisChart
+                rollouts={recentRolloutsWithData
+                  .filter((r) => r && r.steps && r.steps.length > 0)
+                  .map((r) =>
+                    r.steps
+                      .filter((s: any) => s && s.state && s.action !== undefined)
+                      .map((s: any) => ({
+                        state: s.state || {},
+                        action: s.action,
+                        reward: s.reward || 0,
+                        done: s.done || false,
+                      }))
+                  )
+                  .filter((rollout) => rollout.length > 0)}
+                envSpec={envSpec}
+              />
+            </div>
+          </section>
+        )}
+
+        {/* Advanced Analytics Section */}
+        <section>
+          <h3 className="text-sm font-medium mb-3">Advanced Analytics</h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {/* State Coverage */}
+            <div className="border border-border rounded-lg p-4">
+              <h4 className="text-xs font-medium mb-2">State Coverage</h4>
+              {stats && (
+                <div className="space-y-2">
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Unique positions</span>
+                    <span className="font-mono">{stats.uniquePositions}</span>
+                  </div>
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Total positions</span>
+                    <span className="font-mono">{stats.totalPositions}</span>
+                  </div>
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Coverage ratio</span>
+                    <span className="font-mono">{((stats.uniquePositions / stats.totalPositions) * 100).toFixed(1)}%</span>
+                  </div>
+                  <div className="h-2 bg-muted rounded-full overflow-hidden mt-2">
+                    <div
+                      className="h-full bg-blue-500"
+                      style={{ width: `${(stats.uniquePositions / stats.totalPositions) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Reward Statistics */}
+            <div className="border border-border rounded-lg p-4">
+              <h4 className="text-xs font-medium mb-2">Reward Statistics</h4>
+              {stats && (
+                <div className="space-y-2">
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Max step reward</span>
+                    <span className={`font-mono ${stats.maxReward >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                      {stats.maxReward.toFixed(2)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Min step reward</span>
+                    <span className={`font-mono ${stats.minReward >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                      {stats.minReward.toFixed(2)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Positive rewards</span>
+                    <span className="font-mono text-green-600">{stats.positiveRewardCount}</span>
+                  </div>
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Negative rewards</span>
+                    <span className="font-mono text-red-600">{stats.negativeRewardCount}</span>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Behavior Analysis */}
+            <div className="border border-border rounded-lg p-4">
+              <h4 className="text-xs font-medium mb-2">Behavior Analysis</h4>
+              {stats && (
+                <div className="space-y-2">
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Path efficiency</span>
+                    <span className="font-mono">{stats.pathEfficiency.toFixed(1)}%</span>
+                  </div>
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Oscillation rate</span>
+                    <span className={`font-mono ${stats.oscillationRate > 0.3 ? 'text-amber-600' : ''}`}>
+                      {(stats.oscillationRate * 100).toFixed(1)}%
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-xs">
+                    <span className="text-muted-foreground">Steps/unique position</span>
+                    <span className="font-mono">{(stats.totalPositions / stats.uniquePositions).toFixed(2)}</span>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Export Options */}
+            <div className="border border-border rounded-lg p-4">
+              <h4 className="text-xs font-medium mb-2">Export Data</h4>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={() => {
+                    const data = rolloutResult?.steps.map((s, i) => ({
+                      step: i + 1,
+                      action: s.action,
+                      reward: s.reward,
+                      cumulative: s.state.totalReward,
+                      position: s.state.agents[0]?.position,
+                    }))
+                    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+                    const url = URL.createObjectURL(blob)
+                    const a = document.createElement('a')
+                    a.href = url
+                    a.download = 'rollout_data.json'
+                    a.click()
+                  }}
+                  className="px-2 py-1 text-xs border border-border rounded hover:bg-muted"
+                >
+                  JSON
+                </button>
+                <button
+                  onClick={() => {
+                    const data = rolloutResult?.steps || []
+                    const csv = 'Step,Action,Reward,Cumulative,Position_X,Position_Y\n' +
+                      data.map((s, i) => {
+                        const pos = s.state.agents[0]?.position || [0, 0]
+                        return `${i + 1},${s.action},${s.reward},${s.state.totalReward},${pos[0]},${pos[1]}`
+                      }).join('\n')
+                    const blob = new Blob([csv], { type: 'text/csv' })
+                    const url = URL.createObjectURL(blob)
+                    const a = document.createElement('a')
+                    a.href = url
+                    a.download = 'rollout_data.csv'
+                    a.click()
+                  }}
+                  className="px-2 py-1 text-xs border border-border rounded hover:bg-muted"
+                >
+                  CSV
+                </button>
+                <button
+                  onClick={() => {
+                    const summary = {
+                      totalReward: rolloutResult?.totalReward,
+                      episodeLength: rolloutResult?.episodeLength,
+                      success: rolloutResult?.success,
+                      terminationReason: rolloutResult?.terminationReason,
+                      stats: stats,
+                      env: {
+                        type: envSpec.world?.coordinateSystem,
+                        width: envSpec.world?.width,
+                        height: envSpec.world?.height,
+                      }
+                    }
+                    const blob = new Blob([JSON.stringify(summary, null, 2)], { type: 'application/json' })
+                    const url = URL.createObjectURL(blob)
+                    const a = document.createElement('a')
+                    a.href = url
+                    a.download = 'episode_summary.json'
+                    a.click()
+                  }}
+                  className="px-2 py-1 text-xs border border-border rounded hover:bg-muted"
+                >
+                  Summary
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+// Simple metric card component
+function MetricCard({
+  label,
+  value,
+  unit,
+  positive,
+}: {
+  label: string
+  value: string
+  unit?: string
+  positive?: boolean
+}) {
+  return (
+    <div className="border border-border rounded-lg p-3">
+      <div className="text-xs text-muted-foreground mb-1">{label}</div>
+      <div
+        className={`text-lg font-semibold font-mono ${
+          positive === true
+            ? 'text-green-600 dark:text-green-500'
+            : positive === false
+              ? 'text-red-600 dark:text-red-500'
+              : ''
+        }`}
+      >
+        {value}
+      </div>
+      {unit && <div className="text-xs text-muted-foreground">{unit}</div>}
+    </div>
+  )
+}

--- a/app/components/RewardDecompositionHeatmap.tsx
+++ b/app/components/RewardDecompositionHeatmap.tsx
@@ -1,12 +1,22 @@
 /**
  * Reward Decomposition Heatmap Component
- * REQUIRES Python backend - NO FALLBACKS
- * Real calculations use NumPy, SciPy in backend
+ * Clean, professional visualization of reward attribution
  */
 
-import { useEffect, useState } from 'react'
-import { analyzeReward, analyzeRewardStreaming, type RewardAnalysis } from '~/lib/analysisClient'
+import { useEffect, useState, useMemo } from 'react'
+import { analyzeRewardStreaming, type RewardAnalysis } from '~/lib/analysisClient'
 import { EnvSpec } from '~/lib/envSpec'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+} from 'recharts'
 
 interface RewardDecompositionHeatmapProps {
   rolloutSteps: Array<{
@@ -25,33 +35,24 @@ export function RewardDecompositionHeatmap({
   const [analysis, setAnalysis] = useState<RewardAnalysis | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [progress, setProgress] = useState<{ progress: number; message: string } | null>(null)
 
   useEffect(() => {
     if (rolloutSteps.length === 0) return
 
     setLoading(true)
     setError(null)
-    setProgress(null)
 
-    // Use streaming for real-time updates
     const cleanup = analyzeRewardStreaming(
       { rollout_steps: rolloutSteps, env_spec: envSpec },
       {
-        onProgress: (prog, msg) => {
-          setProgress({ progress: prog, message: msg })
-        },
+        onProgress: () => {},
         onComplete: (backendAnalysis) => {
           setAnalysis(backendAnalysis)
-          setProgress(null)
           setLoading(false)
-          console.log('✅ Reward analysis complete - Real Python calculations')
         },
         onError: (err) => {
           setError(err.message)
           setLoading(false)
-          setProgress(null)
-          console.error('❌ Reward analysis failed:', err)
         },
       }
     )
@@ -59,345 +60,195 @@ export function RewardDecompositionHeatmap({
     return cleanup
   }, [rolloutSteps, envSpec])
 
+  // Process chart data
+  const chartData = useMemo(() => {
+    if (!analysis?.cumulative_contributions) return []
+
+    const contributions = analysis.cumulative_contributions
+    const maxLength = Math.max(
+      ...Object.values(contributions).map((v: any) => (Array.isArray(v) ? v.length : 0))
+    )
+
+    // Sample data for performance (max 200 points)
+    const sampleRate = Math.max(1, Math.floor(maxLength / 200))
+
+    return Array.from({ length: Math.ceil(maxLength / sampleRate) }, (_, idx) => {
+      const step = idx * sampleRate
+      const dataPoint: Record<string, number> = { step }
+      Object.entries(contributions).forEach(([rule, values]: [string, any]) => {
+        if (Array.isArray(values) && values[step] !== undefined) {
+          const shortRule = rule.length > 15 ? rule.substring(0, 15) + '...' : rule
+          dataPoint[shortRule] = typeof values[step] === 'number' ? values[step] : 0
+        }
+      })
+      return dataPoint
+    })
+  }, [analysis])
+
+  // Get rule names for chart
+  const ruleNames = useMemo(() => {
+    if (!analysis?.cumulative_contributions) return []
+    return Object.keys(analysis.cumulative_contributions).map((rule) =>
+      rule.length > 15 ? rule.substring(0, 15) + '...' : rule
+    )
+  }, [analysis])
+
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
-        <div className="text-sm mb-2">Running Python analysis (NumPy, SciPy)...</div>
-        {progress && (
-          <div className="text-xs text-muted-foreground">
-            {progress.message}{' '}
-            {progress.progress > 0 && `(${Math.round(progress.progress * 100)}%)`}
-          </div>
-        )}
-        <div className="mt-4 w-64 h-2 bg-muted rounded-full overflow-hidden">
-          <div
-            className="h-full bg-primary transition-all duration-300"
-            style={{ width: `${(progress?.progress || 0) * 100}%` }}
-          />
-        </div>
+      <div className="flex items-center justify-center h-48">
+        <div className="text-sm text-muted-foreground">Analyzing rewards...</div>
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 text-destructive border border-destructive/50 rounded-lg p-4 bg-destructive/10">
-        <div className="font-semibold mb-2">❌ Backend Required</div>
-        <div className="text-sm text-center">{error}</div>
-        <div className="text-xs mt-2 text-muted-foreground">
-          Real Python calculations (NumPy, SciPy) are required. Backend:{' '}
-          <code className="bg-muted px-1 rounded">
-            {import.meta.env.VITE_ROLLOUT_SERVICE_URL || 'http://localhost:8000'}
-          </code>
-        </div>
+      <div className="flex items-center justify-center h-48">
+        <div className="text-sm text-red-600">{error}</div>
       </div>
     )
   }
 
   if (!analysis || !analysis.heatmap_data || analysis.heatmap_data.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64 text-muted-foreground">
-        No reward data available. Add reward rules to see activity.
+      <div className="flex items-center justify-center h-48">
+        <div className="text-sm text-muted-foreground">
+          No reward data. Add reward rules to see activity.
+        </div>
       </div>
     )
   }
 
-  const maxStep = Math.max(
-    ...analysis.heatmap_data.map((d) => d.step || 0),
-    rolloutSteps.length - 1
-  )
-  const rules = Array.from(
-    new Set(analysis.heatmap_data.map((d) => d.rule || 'unknown').filter(Boolean))
-  )
-  const maxValue = Math.max(...analysis.heatmap_data.map((d) => Math.abs(d.value || 0)), 1)
-
-  // Create grid data
-  const gridData: Record<string, Record<number, number>> = {}
-  rules.forEach((rule) => {
-    gridData[rule] = {}
-    for (let step = 0; step <= maxStep; step++) {
-      gridData[rule][step] = 0
-    }
-  })
-
-  analysis.heatmap_data.forEach((d) => {
-    if (!gridData[d.rule]) gridData[d.rule] = {}
-    gridData[d.rule][d.step] = (gridData[d.rule][d.step] || 0) + d.value
-  })
-
-  // Limit display to reasonable number of steps (sample if too many)
-  const displaySteps = maxStep > 100 ? 100 : maxStep + 1
-  const stepInterval = maxStep > 100 ? Math.ceil(maxStep / 100) : 1
+  const rules = Object.keys(analysis.per_rule_stats || {})
+  const colors = ['#6366f1', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4']
 
   return (
-    <div className="space-y-5">
-      {/* Professional Header */}
-      <div className="flex items-center justify-between pb-3 border-b border-border">
+    <div className="space-y-6">
+      {/* Summary Stats */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="border border-border rounded p-3">
+          <div className="text-xs text-muted-foreground">Total Reward</div>
+          <div className={`text-lg font-semibold font-mono ${analysis.episode_total >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            {analysis.episode_total >= 0 ? '+' : ''}{analysis.episode_total.toFixed(2)}
+          </div>
+        </div>
+        <div className="border border-border rounded p-3">
+          <div className="text-xs text-muted-foreground">Episode Length</div>
+          <div className="text-lg font-semibold font-mono">{analysis.episode_length}</div>
+        </div>
+        <div className="border border-border rounded p-3">
+          <div className="text-xs text-muted-foreground">Reward Density</div>
+          <div className="text-lg font-semibold font-mono">{analysis.reward_density.toFixed(4)}</div>
+        </div>
+      </div>
+
+      {/* Rule Performance Table */}
+      {rules.length > 0 && (
         <div>
-          <h3 className="text-xl font-bold text-foreground">Reward Decomposition Analysis</h3>
-          <p className="text-xs text-muted-foreground mt-1">
-            Per-rule reward attribution over episode
-          </p>
-        </div>
-        <div className="text-right">
-          <div className="text-sm font-semibold text-foreground">
-            {analysis.episode_length} steps
+          <h4 className="text-xs font-medium mb-2">Reward Rules Performance</h4>
+          <div className="border border-border rounded-lg overflow-hidden">
+            <table className="w-full text-xs">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="text-left px-3 py-2 font-medium">Rule</th>
+                  <th className="text-right px-3 py-2 font-medium">Total</th>
+                  <th className="text-right px-3 py-2 font-medium">Fires</th>
+                  <th className="text-right px-3 py-2 font-medium">Rate</th>
+                  <th className="text-right px-3 py-2 font-medium">Mean</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rules.map((rule, idx) => {
+                  const stats = analysis.per_rule_stats[rule]
+                  if (!stats) return null
+                  return (
+                    <tr key={rule} className="border-t border-border">
+                      <td className="px-3 py-2">
+                        <div className="flex items-center gap-2">
+                          <div
+                            className="w-2 h-2 rounded-full"
+                            style={{ backgroundColor: colors[idx % colors.length] }}
+                          />
+                          <span className="truncate max-w-[150px]" title={rule}>
+                            {rule}
+                          </span>
+                        </div>
+                      </td>
+                      <td className={`px-3 py-2 text-right font-mono ${stats.total >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                        {stats.total >= 0 ? '+' : ''}{stats.total.toFixed(2)}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono">{stats.fire_count}</td>
+                      <td className="px-3 py-2 text-right font-mono">{(stats.fire_rate * 100).toFixed(1)}%</td>
+                      <td className="px-3 py-2 text-right font-mono">{stats.mean.toFixed(3)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
           </div>
-          <div className="text-xs text-muted-foreground">{rules.length} reward rules</div>
-          <div className="text-xs text-green-600 font-mono mt-1">✓ NumPy/SciPy</div>
-        </div>
-      </div>
-
-      {/* Professional Heatmap Grid */}
-      <div className="space-y-3">
-        <div className="flex items-center justify-between text-xs">
-          <span className="font-semibold text-muted-foreground">Reward Activity Heatmap</span>
-          <span className="text-muted-foreground">
-            {maxStep > 100 ? `Sampled: ${displaySteps} of ${maxStep + 1} steps` : 'All steps'}
-          </span>
-        </div>
-        <div className="overflow-x-auto border border-border rounded-lg bg-gradient-to-br from-muted/20 to-muted/5 p-4 shadow-sm">
-          <div className="space-y-2" style={{ minWidth: `${displaySteps * 10}px` }}>
-            {rules.map((rule, ruleIdx) => (
-              <div key={rule} className="flex items-center gap-3 group">
-                <div className="w-36 text-xs font-semibold truncate text-foreground" title={rule}>
-                  {ruleIdx + 1}. {rule.length > 25 ? rule.substring(0, 25) + '...' : rule}
-                </div>
-                <div className="flex gap-0.5 flex-1 h-8 items-center">
-                  {Array.from({ length: displaySteps }, (_, idx) => {
-                    const step = idx * stepInterval
-                    const value = gridData[rule][step] || 0
-                    const intensity = Math.min(Math.abs(value) / maxValue, 1)
-                    const isPositive = value >= 0
-                    const bgColor = isPositive
-                      ? `rgba(34, 197, 94, ${Math.max(intensity, 0.3)})` // green with minimum visibility
-                      : `rgba(239, 68, 68, ${Math.max(intensity, 0.3)})` // red with minimum visibility
-
-                    return (
-                      <div
-                        key={`${rule}-${step}`}
-                        className="h-full rounded transition-all hover:scale-y-125 cursor-pointer border border-border/30 shadow-sm"
-                        style={{
-                          backgroundColor: value !== 0 ? bgColor : 'rgba(0,0,0,0.05)',
-                          width: `${100 / displaySteps}%`,
-                          minWidth: '3px',
-                        }}
-                        title={`Rule: ${rule}\nStep: ${step}\nReward: ${value.toFixed(3)}`}
-                      />
-                    )
-                  })}
-                </div>
-                <div className="w-20 text-xs text-right font-mono text-muted-foreground">
-                  {(analysis.per_rule_stats?.[rule]?.total || 0) >= 0 ? '+' : ''}
-                  {(analysis.per_rule_stats?.[rule]?.total || 0).toFixed(1)}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div className="flex items-center gap-4 text-xs text-muted-foreground">
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded bg-green-500/60" />
-            <span>Positive reward</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded bg-red-500/60" />
-            <span>Negative reward</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-3 h-3 rounded bg-muted" />
-            <span>No reward</span>
-          </div>
-        </div>
-      </div>
-
-      {/* Professional Statistics Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-        {rules.map((rule, idx) => {
-          const stats = analysis.per_rule_stats?.[rule]
-          if (!stats) return null
-          return (
-            <div
-              key={rule}
-              className="p-4 bg-card rounded-lg border border-border shadow-sm hover:shadow-md transition-shadow"
-            >
-              <div className="flex items-start justify-between mb-2">
-                <div className="font-semibold text-sm text-foreground truncate flex-1" title={rule}>
-                  {idx + 1}. {rule}
-                </div>
-                <div
-                  className={`text-lg font-bold ${(stats.total || 0) >= 0 ? 'text-green-600' : 'text-red-600'}`}
-                >
-                  {(stats.total || 0) >= 0 ? '+' : ''}
-                  {(stats.total || 0).toFixed(2)}
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-2 text-xs">
-                <div>
-                  <div className="text-muted-foreground">Fires</div>
-                  <div className="font-mono font-semibold">{stats.fire_count || 0}</div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground">Rate</div>
-                  <div className="font-mono font-semibold">
-                    {((stats.fire_rate || 0) * 100).toFixed(1)}%
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground">Mean</div>
-                  <div className="font-mono text-xs">{(stats.mean || 0).toFixed(3)}</div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground">Std</div>
-                  <div className="font-mono text-xs">{(stats.std || 0).toFixed(3)}</div>
-                </div>
-              </div>
-            </div>
-          )
-        })}
-      </div>
-
-      {/* Warnings */}
-      {analysis.warnings && Array.isArray(analysis.warnings) && analysis.warnings.length > 0 && (
-        <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-md p-3 text-sm">
-          <div className="font-semibold text-yellow-700 dark:text-yellow-400 mb-2">
-            ⚠️ Warnings:
-          </div>
-          <ul className="list-disc list-inside space-y-1">
-            {analysis.warnings.map((warning, i) => (
-              <li key={i} className="text-yellow-600 dark:text-yellow-400">
-                {warning}
-              </li>
-            ))}
-          </ul>
         </div>
       )}
 
-      {/* Cumulative Contributions Chart - Professional RL Visualization */}
-      {analysis.cumulative_contributions &&
-        Object.keys(analysis.cumulative_contributions).length > 0 && (
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h4 className="text-sm font-semibold">Cumulative Reward Contributions</h4>
-              <span className="text-xs text-muted-foreground font-mono">NumPy cumsum()</span>
-            </div>
-            <div className="h-72 border border-border rounded-lg bg-gradient-to-b from-muted/10 to-muted/5 p-4 shadow-sm">
-              <svg
-                width="100%"
-                height="100%"
-                viewBox={`0 0 ${Math.max(analysis.episode_length, 100)} 200`}
-                preserveAspectRatio="none"
-                className="overflow-visible"
-              >
-                {/* Grid lines */}
-                {Array.from({ length: 5 }, (_, i) => (
-                  <line
-                    key={`grid-${i}`}
-                    x1="0"
-                    y1={40 + i * 40}
-                    x2={analysis.episode_length}
-                    y2={40 + i * 40}
-                    stroke="hsl(var(--border))"
-                    strokeWidth="0.5"
-                    strokeDasharray="2 2"
-                    opacity="0.3"
+      {/* Cumulative Reward Chart */}
+      {chartData.length > 0 && ruleNames.length > 0 && (
+        <div>
+          <h4 className="text-xs font-medium mb-2">Cumulative Rewards Over Time</h4>
+          <div className="border border-border rounded-lg p-4">
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={chartData} margin={{ top: 10, right: 20, left: 10, bottom: 10 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" opacity={0.5} />
+                <XAxis
+                  dataKey="step"
+                  stroke="hsl(var(--muted-foreground))"
+                  fontSize={11}
+                  tickLine={false}
+                />
+                <YAxis
+                  stroke="hsl(var(--muted-foreground))"
+                  fontSize={11}
+                  tickLine={false}
+                  tickFormatter={(v) => v.toFixed(0)}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: 'hsl(var(--popover))',
+                    border: '1px solid hsl(var(--border))',
+                    borderRadius: '6px',
+                    fontSize: '12px',
+                  }}
+                  formatter={(value: number) => value.toFixed(2)}
+                />
+                <Legend
+                  wrapperStyle={{ fontSize: '11px', paddingTop: '10px' }}
+                  iconSize={8}
+                />
+                <ReferenceLine y={0} stroke="hsl(var(--muted-foreground))" strokeDasharray="2 2" opacity={0.5} />
+                {ruleNames.map((rule, idx) => (
+                  <Line
+                    key={rule}
+                    type="monotone"
+                    dataKey={rule}
+                    stroke={colors[idx % colors.length]}
+                    strokeWidth={1.5}
+                    dot={false}
+                    activeDot={{ r: 4 }}
                   />
                 ))}
-
-                {Object.entries(analysis.cumulative_contributions).map(([rule, values], idx) => {
-                  if (!Array.isArray(values) || values.length === 0) return null
-                  const colors = [
-                    '#3b82f6',
-                    '#10b981',
-                    '#f59e0b',
-                    '#ef4444',
-                    '#8b5cf6',
-                    '#ec4899',
-                    '#06b6d4',
-                  ]
-                  const color = colors[idx % colors.length]
-                  const maxVal = Math.max(
-                    ...values.filter((v) => typeof v === 'number' && !isNaN(v)),
-                    1
-                  )
-                  const minVal = Math.min(
-                    ...values.filter((v) => typeof v === 'number' && !isNaN(v)),
-                    0
-                  )
-                  const range = maxVal - minVal || 1
-
-                  const points = values
-                    .map((v, step) => {
-                      const normalizedValue = ((v || 0) - minVal) / range
-                      const x =
-                        values.length > 1
-                          ? (step / (values.length - 1)) * analysis.episode_length
-                          : 0
-                      const y = 190 - normalizedValue * 170 - 10
-                      return `${x},${y}`
-                    })
-                    .filter(
-                      (_, idx) =>
-                        idx === 0 ||
-                        idx === values.length - 1 ||
-                        idx % Math.ceil(values.length / 50) === 0
-                    ) // Sample for performance
-                    .join(' ')
-
-                  if (!points || points.split(' ').length < 2) return null
-
-                  return (
-                    <g key={rule}>
-                      <polyline
-                        points={points}
-                        fill="none"
-                        stroke={color}
-                        strokeWidth="2.5"
-                        opacity="0.9"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      />
-                      {/* Legend */}
-                      <text
-                        x={analysis.episode_length - 5}
-                        y={190 - (((values[values.length - 1] || 0) - minVal) / range) * 170 - 10}
-                        fill={color}
-                        fontSize="11"
-                        textAnchor="end"
-                        className="font-semibold"
-                        style={{ textShadow: '0 1px 2px rgba(0,0,0,0.1)' }}
-                      >
-                        {rule.length > 18 ? rule.substring(0, 18) + '...' : rule}
-                      </text>
-                    </g>
-                  )
-                })}
-
-                {/* Axes */}
-                <line
-                  x1="0"
-                  y1="190"
-                  x2={analysis.episode_length}
-                  y2="190"
-                  stroke="hsl(var(--foreground))"
-                  strokeWidth="1.5"
-                />
-                <line
-                  x1="0"
-                  y1="10"
-                  x2="0"
-                  y2="190"
-                  stroke="hsl(var(--foreground))"
-                  strokeWidth="1.5"
-                />
-              </svg>
-            </div>
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <span>Shows cumulative reward contribution from each rule over time</span>
-              <span className="font-mono">scipy.stats + numpy</span>
-            </div>
+              </LineChart>
+            </ResponsiveContainer>
           </div>
-        )}
+        </div>
+      )}
+
+      {/* Warnings */}
+      {analysis.warnings && analysis.warnings.length > 0 && (
+        <div className="text-xs text-amber-600 space-y-1">
+          {analysis.warnings.map((warning, i) => (
+            <div key={i}>⚠ {warning}</div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }
+

--- a/app/components/StudioBottomPanel.tsx
+++ b/app/components/StudioBottomPanel.tsx
@@ -3,13 +3,22 @@ import { useMutation, useQuery } from 'convex/react'
 import { api } from '../../convex/_generated/api.js'
 import { EnvSpec, Vec2 } from '~/lib/envSpec'
 import { runUniversalRollout, type SimulatorResult } from '~/lib/universalSimulator'
-import { runRolloutHTTP, checkRolloutServiceHealth } from '~/lib/rolloutClient'
+import { runRolloutHTTP, checkRolloutServiceHealth, loadRolloutFromS3 } from '~/lib/rolloutClient'
 import { useAuth } from '~/lib/auth'
 import { CodeViewTab } from './CodeViewTab'
-import { RewardDecompositionHeatmap } from './RewardDecompositionHeatmap'
-import { TrajectoryPathVisualizer } from './TrajectoryPathVisualizer'
-import { TerminationAnalysisChart } from './TerminationAnalysisChart'
-import { PolicyEntropyChart } from './PolicyEntropyChart'
+import { RLAnalysisTab } from './RLAnalysisTab'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  BarChart,
+  Bar,
+} from 'recharts'
 
 type BottomPanelTab = 'rollout' | 'rewards' | 'events' | 'history' | 'code' | 'analysis'
 
@@ -55,13 +64,26 @@ export function StudioBottomPanel({
     return null
   })
   const [maxSteps, setMaxSteps] = useState<number>(() => {
-    // Get maxSteps from timeout rule or default to 100
+    // Get maxSteps from episode config, timeout rule, or default to 2000 for training
+    const episodeMaxSteps = envSpec?.episode?.maxSteps
+    if (episodeMaxSteps) return episodeMaxSteps
     const timeoutRule = envSpec?.rules?.terminations?.find((r) => r.condition.type === 'timeout')
-    return timeoutRule?.condition.steps || 100
+    if (timeoutRule?.condition.steps) return timeoutRule.condition.steps
+    // Default to 2000 for actual RL experiments (was 100 for quick testing)
+    return 2000
   })
   const [isPlaying, setIsPlaying] = useState(false)
   const [playbackSpeed, setPlaybackSpeed] = useState(500) // ms per step
   const [selectedHistoryId, setSelectedHistoryId] = useState<string | null>(null)
+  
+  // Phase 2: Enhanced features state
+  const [eventFilter, setEventFilter] = useState<string>('')
+  const [eventTypeFilter, setEventTypeFilter] = useState<'all' | 'reward' | 'termination' | 'custom'>('all')
+  const [comparisonMode, setComparisonMode] = useState(false)
+  const [selectedForComparison, setSelectedForComparison] = useState<string[]>([])
+
+  // Keep recent rollouts with full step data in memory for analysis
+  const [recentRolloutsWithData, setRecentRolloutsWithData] = useState<SimulatorResult[]>([])
 
   const saveRolloutMutation = useMutation(api.rolloutHistory.create)
   const rolloutHistory = useQuery(
@@ -170,12 +192,25 @@ export function StudioBottomPanel({
       if (backendAvailable) {
         console.log('✅ Using Python backend for rollout')
         try {
+          // Debug: Log reward rules being sent
+          const rewardRules = envSpec.rules?.rewards || []
           console.log('📤 Sending rollout request to backend:', {
             policy,
             maxSteps: effectiveMaxSteps,
             envSpecKeys: Object.keys(envSpec),
             objectsCount: envSpec.objects?.length || 0,
             goalsCount: goals.length,
+            rewardRulesCount: rewardRules.length,
+            rewardRules: rewardRules.map((r: any) => ({
+              id: r.id,
+              condition: r.condition?.type,
+              reward: r.reward,
+            })),
+            rulesStructure: {
+              hasRules: !!envSpec.rules,
+              hasRewards: !!envSpec.rules?.rewards,
+              rewardsType: Array.isArray(envSpec.rules?.rewards) ? 'array' : typeof envSpec.rules?.rewards,
+            },
           })
 
           const response = await runRolloutHTTP({
@@ -214,12 +249,15 @@ export function StudioBottomPanel({
               episodeLength: response.result.episodeLength,
               success: response.result.success,
               terminationReason: response.result.terminationReason,
+              // Store S3 URL if available for later retrieval
+              s3Url: response.result.s3Url,
             }
             console.log('✅ Python backend rollout complete:', {
               totalReward: result.totalReward,
               episodeLength: result.episodeLength,
               success: result.success,
               executionTime: response.executionTime,
+              s3Url: (result as any).s3Url,
             })
           } else {
             throw new Error(response.error || 'Backend rollout failed')
@@ -239,7 +277,17 @@ export function StudioBottomPanel({
       } else {
         console.log('ℹ️ Python backend not available, using TypeScript simulator')
         // Use TypeScript simulator as fallback
-        console.log('🔄 Running TypeScript rollout:', { policy, maxSteps: effectiveMaxSteps })
+        const rewardRules = envSpec.rules?.rewards || []
+        console.log('🔄 Running TypeScript rollout:', {
+          policy,
+          maxSteps: effectiveMaxSteps,
+          rewardRulesCount: rewardRules.length,
+          rewardRules: rewardRules.map((r: any) => ({
+            id: r.id,
+            condition: r.condition?.type,
+            reward: r.reward,
+          })),
+        })
         result = runUniversalRollout(envSpec, policy, effectiveMaxSteps)
         console.log('✅ TypeScript rollout complete:', {
           steps: result.steps.length,
@@ -264,6 +312,17 @@ export function StudioBottomPanel({
 
       setRolloutResult(result)
       setCurrentStepIndex(0)
+      
+      // Clear selected history when new rollout runs - switch to new rollout data
+      // This ensures all tabs (Reward Inspector, Event Log, RL Analysis) use the new rollout
+      setSelectedHistoryId(null)
+
+      // Add to recent rollouts with full data (keep last 10 for analysis)
+      setRecentRolloutsWithData((prev) => {
+        const updated = [result, ...prev].slice(0, 10) // Keep last 10 rollouts
+        console.log(`📊 Stored ${updated.length} rollouts with full data for analysis`)
+        return updated
+      })
 
       // Use requestAnimationFrame to avoid setState during render warning
       requestAnimationFrame(() => {
@@ -311,6 +370,8 @@ export function StudioBottomPanel({
               totalSteps: result.steps.length,
               hasFullData: false, // Indicates this is summary-only
               note: 'Full step data available via backend API for analysis',
+              // Store S3 URL if available for loading full data later
+              s3Url: (result as any).s3Url || null,
             },
           }
 
@@ -338,7 +399,7 @@ export function StudioBottomPanel({
   useEffect(() => {
     if (onRunRollout) {
       // Store the run function in a way parent can call it
-      ;(window as any).__runRollout = handleRunRollout
+      (window as any).__runRollout = handleRunRollout
     }
     return () => {
       delete (window as any).__runRollout
@@ -552,6 +613,28 @@ export function StudioBottomPanel({
 
             {rolloutResult && (
               <div className="space-y-2">
+                {/* Show if viewing historical rollout */}
+                {selectedHistoryId && (
+                  <div className="flex items-center justify-between p-2 bg-blue-500/10 border border-blue-500/20 rounded text-xs">
+                    <span className="text-blue-600 dark:text-blue-400">
+                      📜 Viewing historical rollout
+                    </span>
+                    <button
+                      onClick={() => {
+                        setSelectedHistoryId(null)
+                        // Keep current rolloutResult if it's the latest, or clear it
+                        // The latest rollout should be in recentRolloutsWithData[0]
+                        if (recentRolloutsWithData.length > 0) {
+                          setRolloutResult(recentRolloutsWithData[0])
+                          setCurrentStepIndex(0)
+                        }
+                      }}
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      Switch to latest
+                    </button>
+                  </div>
+                )}
                 <div className="flex items-center gap-2">
                   <button
                     onClick={handleStepBack}
@@ -587,57 +670,117 @@ export function StudioBottomPanel({
                   </button>
                 </div>
 
-                {currentStep && (
-                  <div className="text-xs space-y-1">
-                    <div>
-                      <span className="text-muted-foreground">Action: </span>
-                      <span className="font-mono">
-                        {typeof currentStep.action === 'string'
-                          ? currentStep.action
-                          : `[${currentStep.action.map((a) => a.toFixed(2)).join(', ')}]`}
-                      </span>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Step Reward: </span>
-                      <span
-                        className={`font-mono ${currentStep.reward > 0 ? 'text-green-600' : currentStep.reward < 0 ? 'text-red-600' : ''}`}
-                      >
-                        {currentStep.reward >= 0 ? '+' : ''}
-                        {currentStep.reward.toFixed(2)}
-                      </span>
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Cumulative: </span>
-                      <span
-                        className={`font-mono ${currentStep.state.totalReward > 0 ? 'text-green-600' : currentStep.state.totalReward < 0 ? 'text-red-600' : ''}`}
-                      >
-                        {currentStep.state.totalReward.toFixed(2)}
-                      </span>
-                    </div>
-                    {currentStep.state.agents.length > 0 && (
+                {/* Step Info and Mini-Map Row */}
+                <div className="flex gap-4">
+                  {/* Step Info */}
+                  {currentStep && (
+                    <div className="text-xs space-y-1 flex-1">
                       <div>
-                        <span className="text-muted-foreground">Position: </span>
+                        <span className="text-muted-foreground">Action: </span>
                         <span className="font-mono">
-                          ({currentStep.state.agents[0].position[0].toFixed(1)},{' '}
-                          {currentStep.state.agents[0].position[1].toFixed(1)})
+                          {typeof currentStep.action === 'string'
+                            ? currentStep.action
+                            : `[${currentStep.action.map((a) => a.toFixed(2)).join(', ')}]`}
                         </span>
                       </div>
-                    )}
-                    {currentStep.state.info.rewards.length > 0 && (
                       <div>
-                        <span className="text-muted-foreground">Reward sources: </span>
-                        <div className="ml-4 space-y-0.5">
-                          {currentStep.state.info.rewards.map((r, i) => (
-                            <div key={i} className="text-xs">
-                              {r.reason}: {r.value >= 0 ? '+' : ''}
-                              {r.value.toFixed(2)}
-                            </div>
-                          ))}
-                        </div>
+                        <span className="text-muted-foreground">Step Reward: </span>
+                        <span
+                          className={`font-mono ${currentStep.reward > 0 ? 'text-green-600' : currentStep.reward < 0 ? 'text-red-600' : ''}`}
+                        >
+                          {currentStep.reward >= 0 ? '+' : ''}
+                          {currentStep.reward.toFixed(2)}
+                        </span>
                       </div>
-                    )}
+                      <div>
+                        <span className="text-muted-foreground">Cumulative: </span>
+                        <span
+                          className={`font-mono ${currentStep.state.totalReward > 0 ? 'text-green-600' : currentStep.state.totalReward < 0 ? 'text-red-600' : ''}`}
+                        >
+                          {currentStep.state.totalReward.toFixed(2)}
+                        </span>
+                      </div>
+                      {currentStep.state.agents.length > 0 && (
+                        <div>
+                          <span className="text-muted-foreground">Position: </span>
+                          <span className="font-mono">
+                            ({currentStep.state.agents[0].position[0].toFixed(1)},{' '}
+                            {currentStep.state.agents[0].position[1].toFixed(1)})
+                          </span>
+                        </div>
+                      )}
+                      {currentStep.state.info.rewards.length > 0 && (
+                        <div>
+                          <span className="text-muted-foreground">Reward sources: </span>
+                          <div className="ml-4 space-y-0.5">
+                            {currentStep.state.info.rewards.map((r, i) => (
+                              <div key={i} className="text-xs">
+                                {r.reason}: {r.value >= 0 ? '+' : ''}
+                                {r.value.toFixed(2)}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  
+                  {/* Mini-Map */}
+                  <div className="w-32 h-32 border border-border rounded bg-muted/30 relative overflow-hidden flex-shrink-0">
+                    <svg width="100%" height="100%" viewBox={`0 0 ${envSpec.world?.width || 10} ${envSpec.world?.height || 10}`}>
+                      {/* Grid */}
+                      {Array.from({ length: (envSpec.world?.width || 10) + 1 }, (_, i) => (
+                        <line key={`v-${i}`} x1={i} y1={0} x2={i} y2={envSpec.world?.height || 10} stroke="currentColor" strokeWidth={0.05} opacity={0.2} />
+                      ))}
+                      {Array.from({ length: (envSpec.world?.height || 10) + 1 }, (_, i) => (
+                        <line key={`h-${i}`} x1={0} y1={i} x2={envSpec.world?.width || 10} y2={i} stroke="currentColor" strokeWidth={0.05} opacity={0.2} />
+                      ))}
+                      {/* Objects */}
+                      {(envSpec.objects || []).map((obj, i) => (
+                        <rect
+                          key={i}
+                          x={obj.position?.[0] || 0}
+                          y={obj.position?.[1] || 0}
+                          width={0.8}
+                          height={0.8}
+                          fill={obj.type === 'goal' ? '#22c55e' : obj.type === 'trap' ? '#ef4444' : '#6b7280'}
+                          opacity={0.6}
+                        />
+                      ))}
+                      {/* Trajectory path */}
+                      {rolloutResult.steps.length > 1 && (
+                        <polyline
+                          points={rolloutResult.steps
+                            .slice(0, currentStepIndex + 1)
+                            .map((s) => {
+                              const pos = s.state.agents[0]?.position
+                              return pos ? `${pos[0] + 0.5},${pos[1] + 0.5}` : ''
+                            })
+                            .filter(Boolean)
+                            .join(' ')}
+                          fill="none"
+                          stroke="#3b82f6"
+                          strokeWidth={0.15}
+                          opacity={0.6}
+                        />
+                      )}
+                      {/* Current agent position */}
+                      {currentStep?.state.agents[0]?.position && (
+                        <circle
+                          cx={currentStep.state.agents[0].position[0] + 0.5}
+                          cy={currentStep.state.agents[0].position[1] + 0.5}
+                          r={0.4}
+                          fill="#3b82f6"
+                          stroke="white"
+                          strokeWidth={0.1}
+                        />
+                      )}
+                    </svg>
+                    <div className="absolute bottom-0.5 right-0.5 text-[8px] text-muted-foreground">
+                      mini-map
+                    </div>
                   </div>
-                )}
+                </div>
               </div>
             )}
 
@@ -650,210 +793,585 @@ export function StudioBottomPanel({
         )}
 
         {activeTab === 'rewards' && (
-          <div className="text-sm">
-            <div className="space-y-2">
-              {rolloutResult && currentStep ? (
-                // Show rewards from current step
-                <div className="space-y-2">
-                  <div className="text-xs font-medium text-muted-foreground mb-2">
-                    Step {currentStepIndex + 1} Rewards:
+          <div className="p-4 h-full overflow-y-auto">
+            {/* Summary stats */}
+            {rolloutResult && (
+              <div className="grid grid-cols-4 gap-3 mb-4">
+                <div className="border border-border rounded p-2">
+                  <div className="text-xs text-muted-foreground">Total Reward</div>
+                  <div className={`text-lg font-mono font-semibold ${rolloutResult.totalReward >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {rolloutResult.totalReward >= 0 ? '+' : ''}{rolloutResult.totalReward.toFixed(2)}
                   </div>
-                  {currentStep.state.info.rewards && currentStep.state.info.rewards.length > 0 ? (
-                    currentStep.state.info.rewards.map((r: any, i: number) => (
-                      <div
-                        key={i}
-                        className="flex items-center justify-between p-2 bg-muted rounded"
-                      >
-                        <div>
-                          <span className="text-xs font-medium">{r.reason || 'unknown'}</span>
-                          {r.ruleId && r.ruleId !== 'unknown' && (
-                            <span className="text-xs text-muted-foreground ml-2">({r.ruleId})</span>
-                          )}
-                        </div>
-                        <span
-                          className={`font-mono ${r.value >= 0 ? 'text-green-600' : 'text-red-600'}`}
-                        >
-                          {r.value >= 0 ? '+' : ''}
-                          {r.value.toFixed(2)}
-                        </span>
-                      </div>
-                    ))
-                  ) : (
-                    <p className="text-muted-foreground text-xs">No rewards for this step</p>
-                  )}
                 </div>
-              ) : (
-                // Show reward rules from envSpec
-                <>
-                  {envSpec?.rules?.rewards && envSpec.rules.rewards.length > 0 ? (
-                    <div className="space-y-2">
-                      <div className="text-xs font-medium text-muted-foreground mb-2">
-                        Configured Reward Rules:
-                      </div>
-                      {envSpec.rules.rewards.map((rule) => (
-                        <div
-                          key={rule.id}
-                          className="flex items-center justify-between p-2 bg-muted rounded"
-                        >
-                          <div>
-                            <span className="text-xs font-medium">{rule.condition.type}</span>
-                            {rule.shaping && (
-                              <span className="text-xs text-muted-foreground ml-2">(shaping)</span>
-                            )}
-                          </div>
-                          <span
-                            className={`font-mono ${rule.reward >= 0 ? 'text-green-600' : 'text-red-600'}`}
-                          >
-                            {rule.reward >= 0 ? '+' : ''}
-                            {rule.reward}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="space-y-2 p-4 border border-yellow-500/50 bg-yellow-500/10 rounded">
-                      <p className="text-xs font-medium text-yellow-700 dark:text-yellow-400">
-                        ⚠️ No reward rules defined
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        Add reward rules in the <strong>Rules panel</strong> (right sidebar →
-                        Rewards tab) before running rollout.
-                      </p>
-                      <p className="text-xs text-muted-foreground mt-2">Common rules:</p>
-                      <ul className="text-xs text-muted-foreground ml-4 list-disc space-y-1">
-                        <li>Goal reached: +10</li>
-                        <li>Per step: -0.1</li>
-                        <li>Trap hit: -10</li>
-                      </ul>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
+                <div className="border border-border rounded p-2">
+                  <div className="text-xs text-muted-foreground">Current Step</div>
+                  <div className="text-lg font-mono font-semibold">{currentStepIndex + 1}</div>
+                </div>
+                <div className="border border-border rounded p-2">
+                  <div className="text-xs text-muted-foreground">Step Reward</div>
+                  <div className={`text-lg font-mono font-semibold ${(currentStep?.reward || 0) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {(currentStep?.reward || 0) >= 0 ? '+' : ''}{(currentStep?.reward || 0).toFixed(2)}
+                  </div>
+                </div>
+                <div className="border border-border rounded p-2">
+                  <div className="text-xs text-muted-foreground">Cumulative</div>
+                  <div className={`text-lg font-mono font-semibold ${(currentStep?.state?.totalReward || 0) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {(currentStep?.state?.totalReward || 0) >= 0 ? '+' : ''}{(currentStep?.state?.totalReward || 0).toFixed(2)}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Reward Timeline Chart */}
+            {rolloutResult && rolloutResult.steps.length > 0 && (
+              <div className="mb-4">
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-xs font-medium">Reward Timeline</h3>
+                  <button
+                    onClick={() => {
+                      const data = rolloutResult.steps.map((s, i) => ({
+                        step: i + 1,
+                        reward: s.reward,
+                        cumulative: s.state.totalReward
+                      }))
+                      const csv = 'Step,Reward,Cumulative\n' + data.map(d => `${d.step},${d.reward},${d.cumulative}`).join('\n')
+                      const blob = new Blob([csv], { type: 'text/csv' })
+                      const url = URL.createObjectURL(blob)
+                      const a = document.createElement('a')
+                      a.href = url
+                      a.download = 'rewards.csv'
+                      a.click()
+                    }}
+                    className="text-xs text-muted-foreground hover:text-foreground"
+                  >
+                    Export CSV
+                  </button>
+                </div>
+                <div className="border border-border rounded-lg p-3">
+                  <ResponsiveContainer width="100%" height={150}>
+                    <LineChart
+                      data={rolloutResult.steps.map((s, i) => ({
+                        step: i + 1,
+                        reward: s.reward,
+                        cumulative: s.state.totalReward
+                      }))}
+                      margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
+                    >
+                      <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" opacity={0.5} />
+                      <XAxis dataKey="step" fontSize={10} stroke="hsl(var(--muted-foreground))" tickLine={false} />
+                      <YAxis fontSize={10} stroke="hsl(var(--muted-foreground))" tickLine={false} />
+                      <Tooltip
+                        contentStyle={{
+                          backgroundColor: 'hsl(var(--popover))',
+                          border: '1px solid hsl(var(--border))',
+                          borderRadius: '6px',
+                          fontSize: '11px',
+                        }}
+                      />
+                      <ReferenceLine y={0} stroke="hsl(var(--muted-foreground))" strokeDasharray="2 2" opacity={0.5} />
+                      <ReferenceLine x={currentStepIndex + 1} stroke="#f59e0b" strokeWidth={2} />
+                      <Line type="monotone" dataKey="reward" stroke="#ef4444" strokeWidth={1} dot={false} name="Step Reward" />
+                      <Line type="monotone" dataKey="cumulative" stroke="#22c55e" strokeWidth={1.5} dot={false} name="Cumulative" />
+                    </LineChart>
+                  </ResponsiveContainer>
+                  <div className="flex justify-center gap-4 mt-2 text-xs">
+                    <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-red-500"></span> Step</span>
+                    <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-green-500"></span> Cumulative</span>
+                    <span className="flex items-center gap-1"><span className="w-3 h-0.5 bg-amber-500"></span> Current</span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Current step rewards */}
+            {rolloutResult && currentStep ? (
+              <div>
+                <h3 className="text-xs font-medium mb-2">Step {currentStepIndex + 1} Reward Sources</h3>
+                {currentStep.state.info.rewards && currentStep.state.info.rewards.length > 0 ? (
+                  <div className="border border-border rounded-lg overflow-hidden">
+                    <table className="w-full text-xs">
+                      <thead className="bg-muted/50">
+                        <tr>
+                          <th className="text-left px-3 py-2 font-medium">Rule</th>
+                          <th className="text-left px-3 py-2 font-medium">Reason</th>
+                          <th className="text-right px-3 py-2 font-medium">Value</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {currentStep.state.info.rewards.map((r: any, i: number) => (
+                          <tr key={i} className="border-t border-border">
+                            <td className="px-3 py-2 font-mono text-muted-foreground">{r.ruleId || '-'}</td>
+                            <td className="px-3 py-2">{r.reason || 'unknown'}</td>
+                            <td className={`px-3 py-2 text-right font-mono ${r.value >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                              {r.value >= 0 ? '+' : ''}{r.value.toFixed(2)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="text-xs text-muted-foreground p-3 border border-border rounded">
+                    No rewards triggered this step
+                  </div>
+                )}
+              </div>
+            ) : (
+              // Show configured rules
+              <div>
+                <h3 className="text-xs font-medium mb-2">Configured Reward Rules</h3>
+                {envSpec?.rules?.rewards && envSpec.rules.rewards.length > 0 ? (
+                  <div className="border border-border rounded-lg overflow-hidden">
+                    <table className="w-full text-xs">
+                      <thead className="bg-muted/50">
+                        <tr>
+                          <th className="text-left px-3 py-2 font-medium">Condition</th>
+                          <th className="text-left px-3 py-2 font-medium">Type</th>
+                          <th className="text-right px-3 py-2 font-medium">Reward</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {envSpec.rules.rewards.map((rule) => (
+                          <tr key={rule.id} className="border-t border-border">
+                            <td className="px-3 py-2">{rule.condition.type}</td>
+                            <td className="px-3 py-2 text-muted-foreground">{rule.shaping ? 'Shaping' : 'Sparse'}</td>
+                            <td className={`px-3 py-2 text-right font-mono ${rule.reward >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                              {rule.reward >= 0 ? '+' : ''}{rule.reward}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="text-xs text-muted-foreground p-3 border border-amber-500/30 bg-amber-500/5 rounded">
+                    No reward rules configured. Add rules in the Properties panel → Rewards tab.
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
 
         {activeTab === 'events' && (
-          <div className="text-sm h-full flex flex-col">
+          <div className="p-4 h-full flex flex-col">
             {rolloutResult && rolloutResult.steps.length > 0 ? (
               <>
-                <div className="mb-2 text-xs text-muted-foreground">
-                  Showing events up to step {currentStepIndex + 1} / {rolloutResult.steps.length}
+                {/* Filter controls */}
+                <div className="flex items-center gap-3 mb-3">
+                  <input
+                    type="text"
+                    placeholder="Search events..."
+                    value={eventFilter}
+                    onChange={(e) => setEventFilter(e.target.value)}
+                    className="flex-1 px-2 py-1 text-xs border border-border rounded bg-background"
+                  />
+                  <select
+                    value={eventTypeFilter}
+                    onChange={(e) => setEventTypeFilter(e.target.value as any)}
+                    className="px-2 py-1 text-xs border border-border rounded bg-background"
+                  >
+                    <option value="all">All Types</option>
+                    <option value="reward">Rewards</option>
+                    <option value="termination">Terminations</option>
+                    <option value="custom">Custom</option>
+                  </select>
+                  <button
+                    onClick={() => {
+                      const allEvents = rolloutResult.steps
+                        .slice(0, currentStepIndex + 1)
+                        .flatMap((step, idx) => (step.state.info.events || []).map(e => ({ step: idx + 1, event: e })))
+                      const csv = 'Step,Event\n' + allEvents.map(e => `${e.step},"${e.event}"`).join('\n')
+                      const blob = new Blob([csv], { type: 'text/csv' })
+                      const url = URL.createObjectURL(blob)
+                      const a = document.createElement('a')
+                      a.href = url
+                      a.download = 'events.csv'
+                      a.click()
+                    }}
+                    className="px-2 py-1 text-xs border border-border rounded hover:bg-muted"
+                  >
+                    Export
+                  </button>
                 </div>
-                <div className="flex-1 overflow-y-auto space-y-0.5 pr-2">
-                  {rolloutResult.steps
-                    .slice(0, currentStepIndex + 1)
-                    .map((step, stepIdx) =>
-                      step.state.info.events?.map((event, eventIdx) => (
-                        <div
-                          key={`${stepIdx}-${eventIdx}`}
-                          className="text-xs text-muted-foreground p-1.5 hover:bg-muted/50 rounded transition-colors border-l-2 border-transparent hover:border-primary/30"
-                        >
-                          <span className="text-muted-foreground/60 font-mono text-[10px] mr-2">
-                            Step {stepIdx + 1}:
-                          </span>
-                          {event}
-                        </div>
-                      ))
-                    )
-                    .flat()}
+
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-xs text-muted-foreground">
+                    Steps 1-{currentStepIndex + 1} of {rolloutResult.steps.length}
+                  </span>
+                  <span className="text-xs font-mono text-muted-foreground">
+                    {(() => {
+                      const allEvents = rolloutResult.steps
+                        .slice(0, currentStepIndex + 1)
+                        .flatMap((step) => step.state.info.events || [])
+                        .filter(e => {
+                          if (eventFilter && !e.toLowerCase().includes(eventFilter.toLowerCase())) return false
+                          if (eventTypeFilter === 'reward' && !e.toLowerCase().includes('reward')) return false
+                          if (eventTypeFilter === 'termination' && !e.toLowerCase().includes('terminat')) return false
+                          return true
+                        })
+                      return `${allEvents.length} events`
+                    })()}
+                  </span>
+                </div>
+
+                <div className="flex-1 overflow-y-auto border border-border rounded-lg">
+                  <table className="w-full text-xs">
+                    <thead className="bg-muted/50 sticky top-0">
+                      <tr>
+                        <th className="text-left px-3 py-2 font-medium w-16">Step</th>
+                        <th className="text-left px-3 py-2 font-medium">Event</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rolloutResult.steps
+                        .slice(0, currentStepIndex + 1)
+                        .flatMap((step, stepIdx) =>
+                          (step.state.info.events || [])
+                            .filter(event => {
+                              if (eventFilter && !event.toLowerCase().includes(eventFilter.toLowerCase())) return false
+                              if (eventTypeFilter === 'reward' && !event.toLowerCase().includes('reward')) return false
+                              if (eventTypeFilter === 'termination' && !event.toLowerCase().includes('terminat')) return false
+                              return true
+                            })
+                            .map((event, eventIdx) => (
+                              <tr
+                                key={`${stepIdx}-${eventIdx}`}
+                                className="border-t border-border hover:bg-muted/30 cursor-pointer"
+                                onClick={() => setCurrentStepIndex(stepIdx)}
+                              >
+                                <td className="px-3 py-1.5 font-mono text-muted-foreground">{stepIdx + 1}</td>
+                                <td className="px-3 py-1.5">
+                                  {event.toLowerCase().includes('reward') && <span className="text-green-600 mr-1">●</span>}
+                                  {event.toLowerCase().includes('terminat') && <span className="text-red-600 mr-1">●</span>}
+                                  {event}
+                                </td>
+                              </tr>
+                            ))
+                        )}
+                    </tbody>
+                  </table>
+                  {rolloutResult.steps.slice(0, currentStepIndex + 1).every(step => !step.state.info.events?.length) && (
+                    <div className="p-4 text-center text-xs text-muted-foreground">
+                      No events triggered yet
+                    </div>
+                  )}
                 </div>
               </>
             ) : (
               <div className="flex-1 flex items-center justify-center">
-                <p className="text-muted-foreground text-sm">Run a rollout to see events</p>
+                <p className="text-xs text-muted-foreground">Run a rollout to see events</p>
               </div>
             )}
           </div>
         )}
 
         {activeTab === 'history' && (
-          <div className="text-sm">
+          <div className="p-4 h-full overflow-y-auto">
             {!envId ? (
-              <p className="text-muted-foreground">Save the environment to track rollout history</p>
+              <div className="flex items-center justify-center h-full">
+                <p className="text-xs text-muted-foreground">Save the environment to track history</p>
+              </div>
             ) : rolloutHistory === undefined ? (
-              <p className="text-muted-foreground">Loading history...</p>
+              <div className="flex items-center justify-center h-full">
+                <p className="text-xs text-muted-foreground">Loading...</p>
+              </div>
             ) : rolloutHistory.length === 0 ? (
-              <p className="text-muted-foreground">
-                No rollout history yet. Run a rollout to see it here.
-              </p>
+              <div className="flex items-center justify-center h-full">
+                <p className="text-xs text-muted-foreground">No rollout history. Run a rollout to start.</p>
+              </div>
             ) : (
-              <div className="space-y-2">
+              <div>
+                {/* Controls */}
                 <div className="flex items-center justify-between mb-3">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    {rolloutHistory.length} rollouts
-                  </span>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-muted-foreground">{rolloutHistory.length} rollouts</span>
+                    <button
+                      onClick={() => {
+                        setComparisonMode(!comparisonMode)
+                        if (comparisonMode) setSelectedForComparison([])
+                      }}
+                      className={`px-2 py-1 text-xs border rounded ${comparisonMode ? 'bg-primary text-primary-foreground border-primary' : 'border-border hover:bg-muted'}`}
+                    >
+                      {comparisonMode ? 'Exit Compare' : 'Compare'}
+                    </button>
+                    {comparisonMode && selectedForComparison.length > 0 && (
+                      <span className="text-xs text-muted-foreground">{selectedForComparison.length} selected</span>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => {
+                      const data = rolloutHistory.map(h => ({
+                        time: new Date(h.createdAt).toISOString(),
+                        policy: h.policy,
+                        success: h.result?.success,
+                        reward: h.result?.totalReward,
+                        steps: h.result?.episodeLength
+                      }))
+                      const csv = 'Time,Policy,Success,Reward,Steps\n' + data.map(d => `${d.time},${d.policy},${d.success},${d.reward},${d.steps}`).join('\n')
+                      const blob = new Blob([csv], { type: 'text/csv' })
+                      const url = URL.createObjectURL(blob)
+                      const a = document.createElement('a')
+                      a.href = url
+                      a.download = 'rollout_history.csv'
+                      a.click()
+                    }}
+                    className="px-2 py-1 text-xs border border-border rounded hover:bg-muted"
+                  >
+                    Export All
+                  </button>
                 </div>
-                <div className="space-y-2 max-h-64 overflow-y-auto">
-                  {rolloutHistory.map((history) => {
-                    const result = history.result as SimulatorResult
-                    const isSelected = selectedHistoryId === history._id
-                    // Check if this is summary-only (no step data)
-                    const isSummaryOnly =
-                      result?._metadata?.hasFullData === false ||
-                      (result?.steps?.length === 0 && result?.episodeLength > 0)
-                    const hasSteps = result && result.steps && result.steps.length > 0
 
-                    return (
-                      <div
-                        key={history._id}
-                        onClick={() => {
-                          if (isSummaryOnly) {
-                            alert(
-                              'This rollout is stored as summary-only to save space. Re-run the rollout to see full visualization, or use RL Analysis tab for detailed analysis.'
-                            )
-                          } else if (hasSteps) {
-                            setSelectedHistoryId(history._id)
-                            setRolloutResult(result)
-                            setCurrentStepIndex(0)
-                            setIsPlaying(false)
-                            if (result.steps.length > 0 && onStepChange) {
-                              onStepChange({ agents: result.steps[0].state.agents })
-                            }
+                {/* Comparison Chart */}
+                {comparisonMode && selectedForComparison.length >= 2 && (
+                  <div className="mb-4 border border-border rounded-lg p-3">
+                    <h4 className="text-xs font-medium mb-2">Comparison: Reward Distribution</h4>
+                    <ResponsiveContainer width="100%" height={120}>
+                      <BarChart
+                        data={selectedForComparison.map((id, idx) => {
+                          const h = rolloutHistory.find(r => r._id === id)
+                          return {
+                            name: `#${idx + 1}`,
+                            reward: h?.result?.totalReward || 0,
+                            steps: h?.result?.episodeLength || 0
                           }
-                        }}
-                        className={`p-3 border rounded cursor-pointer transition-colors ${
-                          isSelected
-                            ? 'border-primary bg-primary/5'
-                            : 'border-border hover:bg-muted'
-                        } ${isSummaryOnly ? 'opacity-70' : ''}`}
+                        })}
+                        margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
                       >
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            <span className="text-xs font-medium capitalize">{history.policy}</span>
-                            <span className="text-xs text-muted-foreground">
-                              {new Date(history.createdAt).toLocaleTimeString()}
-                            </span>
-                            {isSummaryOnly && (
-                              <span
-                                className="text-xs text-blue-600"
-                                title="Summary-only (full data available via backend)"
-                              >
-                                (summary)
-                              </span>
-                            )}
-                          </div>
-                          <div className="flex items-center gap-3 text-xs">
-                            <span className={result?.success ? 'text-green-600' : 'text-red-600'}>
-                              {result?.success ? '✓' : '✗'}
-                            </span>
-                            <span className="text-muted-foreground">
-                              Reward:{' '}
-                              <span className="font-mono">
-                                {result?.totalReward?.toFixed(2) || 'N/A'}
-                              </span>
-                            </span>
-                            <span className="text-muted-foreground">
-                              Steps:{' '}
-                              <span className="font-mono">
-                                {result?.episodeLength || result?._metadata?.totalSteps || 'N/A'}
-                              </span>
-                            </span>
-                          </div>
+                        <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" opacity={0.5} />
+                        <XAxis dataKey="name" fontSize={10} stroke="hsl(var(--muted-foreground))" />
+                        <YAxis fontSize={10} stroke="hsl(var(--muted-foreground))" />
+                        <Tooltip
+                          contentStyle={{
+                            backgroundColor: 'hsl(var(--popover))',
+                            border: '1px solid hsl(var(--border))',
+                            borderRadius: '6px',
+                            fontSize: '11px',
+                          }}
+                        />
+                        <Bar dataKey="reward" fill="#22c55e" name="Reward" />
+                      </BarChart>
+                    </ResponsiveContainer>
+                    <div className="mt-2 grid grid-cols-3 gap-2 text-xs">
+                      <div className="border border-border rounded p-2">
+                        <div className="text-muted-foreground">Avg Reward</div>
+                        <div className="font-mono font-semibold">
+                          {(selectedForComparison.reduce((sum, id) => {
+                            const h = rolloutHistory.find(r => r._id === id)
+                            return sum + (h?.result?.totalReward || 0)
+                          }, 0) / selectedForComparison.length).toFixed(2)}
                         </div>
                       </div>
-                    )
-                  })}
+                      <div className="border border-border rounded p-2">
+                        <div className="text-muted-foreground">Avg Steps</div>
+                        <div className="font-mono font-semibold">
+                          {Math.round(selectedForComparison.reduce((sum, id) => {
+                            const h = rolloutHistory.find(r => r._id === id)
+                            return sum + (h?.result?.episodeLength || 0)
+                          }, 0) / selectedForComparison.length)}
+                        </div>
+                      </div>
+                      <div className="border border-border rounded p-2">
+                        <div className="text-muted-foreground">Success Rate</div>
+                        <div className="font-mono font-semibold">
+                          {Math.round((selectedForComparison.filter(id => {
+                            const h = rolloutHistory.find(r => r._id === id)
+                            return h?.result?.success
+                          }).length / selectedForComparison.length) * 100)}%
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                <div className="border border-border rounded-lg overflow-hidden">
+                  <table className="w-full text-xs">
+                    <thead className="bg-muted/50">
+                      <tr>
+                        {comparisonMode && <th className="text-center px-2 py-2 font-medium w-8"></th>}
+                        <th className="text-left px-3 py-2 font-medium">Time</th>
+                        <th className="text-left px-3 py-2 font-medium">Policy</th>
+                        <th className="text-center px-3 py-2 font-medium">Status</th>
+                        <th className="text-right px-3 py-2 font-medium">Reward</th>
+                        <th className="text-right px-3 py-2 font-medium">Steps</th>
+                        <th className="text-center px-3 py-2 font-medium w-16"></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rolloutHistory.map((history) => {
+                        const result = history.result as SimulatorResult
+                        const isSelected = selectedHistoryId === history._id
+                        const isCompareSelected = selectedForComparison.includes(history._id)
+                        const isSummaryOnly =
+                          (result as any)?._metadata?.hasFullData === false ||
+                          (result?.steps?.length === 0 && result?.episodeLength > 0)
+                        const hasSteps = result && result.steps && Array.isArray(result.steps) && result.steps.length > 0
+                        const s3Url = (result as any)?._metadata?.s3Url
+                        const hasS3Url = !!s3Url
+
+                        return (
+                          <tr
+                            key={history._id}
+                            className={`border-t border-border cursor-pointer transition-colors ${
+                              isSelected ? 'bg-primary/5' : isCompareSelected ? 'bg-blue-500/10' : 'hover:bg-muted/50'
+                            } ${isSummaryOnly ? 'opacity-60' : ''}`}
+                            onClick={async () => {
+                              if (comparisonMode) {
+                                if (isCompareSelected) {
+                                  setSelectedForComparison(selectedForComparison.filter(id => id !== history._id))
+                                } else {
+                                  setSelectedForComparison([...selectedForComparison, history._id])
+                                }
+                              } else if (isSummaryOnly || !hasSteps) {
+                                // Try to load from S3 or in-memory cache
+                                console.log('🔍 Loading historical rollout:', {
+                                  historyId: history._id,
+                                  isSummaryOnly,
+                                  hasSteps,
+                                  hasS3Url,
+                                  s3Url: s3Url,
+                                  metadata: (result as any)?._metadata,
+                                  episodeLength: result.episodeLength,
+                                  totalReward: result.totalReward,
+                                  success: result.success,
+                                  recentRolloutsCount: recentRolloutsWithData.length,
+                                })
+                                
+                                // Check in-memory cache first (most reliable)
+                                // Try to match by multiple criteria for better accuracy
+                                const cachedRollout = recentRolloutsWithData.find((r) => {
+                                  // Match by episode length, total reward, and success status
+                                  const lengthMatch = r.episodeLength === result.episodeLength
+                                  const rewardMatch = Math.abs(r.totalReward - (result.totalReward || 0)) < 0.01
+                                  const successMatch = r.success === result.success
+                                  return lengthMatch && rewardMatch && successMatch
+                                })
+                                
+                                if (cachedRollout) {
+                                  console.log('✅ Found rollout in memory cache, using cached data')
+                                  // Found in cache - use it
+                                  setSelectedHistoryId(history._id)
+                                  setRolloutResult(cachedRollout)
+                                  setCurrentStepIndex(0)
+                                  setIsPlaying(false)
+                                  if (cachedRollout.steps.length > 0 && onStepChange) {
+                                    onStepChange({ agents: cachedRollout.steps[0].state.agents })
+                                  }
+                                  // Switch to rollout preview tab to show the data
+                                  setActiveTab('rollout')
+                                } else if (hasS3Url && s3Url) {
+                                  console.log('📥 Loading rollout from S3:', s3Url)
+                                  // Try to load from S3
+                                  setLoadingHistoryRollout(true)
+                                  try {
+                                    const loadedResult = await loadRolloutFromS3(s3Url)
+                                    if (loadedResult.success && loadedResult.result) {
+                                      const fullResult: SimulatorResult = {
+                                        steps: loadedResult.result.steps.map((step: any) => ({
+                                          state: {
+                                            agents: step.state.agents.map((a: any) => ({
+                                              id: a.id,
+                                              position: a.position,
+                                            })),
+                                            objects: step.state.objects,
+                                            step: step.state.step,
+                                            totalReward: step.state.totalReward,
+                                            done: step.state.done,
+                                            info: step.state.info,
+                                          },
+                                          action: step.action,
+                                          reward: step.reward,
+                                          done: step.done,
+                                        })),
+                                        totalReward: loadedResult.result.totalReward,
+                                        episodeLength: loadedResult.result.episodeLength,
+                                        success: loadedResult.result.success,
+                                        terminationReason: loadedResult.result.terminationReason,
+                                      }
+                                      
+                                      setSelectedHistoryId(history._id)
+                                      setRolloutResult(fullResult)
+                                      setCurrentStepIndex(0)
+                                      setIsPlaying(false)
+                                      if (fullResult.steps.length > 0 && onStepChange) {
+                                        onStepChange({ agents: fullResult.steps[0].state.agents })
+                                      }
+                                      // Switch to rollout preview tab to show the data
+                                      setActiveTab('rollout')
+                                    } else {
+                                      alert('Failed to load rollout data from storage')
+                                    }
+                                  } catch (error) {
+                                    console.error('Failed to load rollout from S3:', error)
+                                    alert('Failed to load rollout data. The rollout may have been deleted or storage is unavailable.')
+                                  } finally {
+                                    setLoadingHistoryRollout(false)
+                                  }
+                                } else {
+                                  console.warn('❌ No S3 URL or cache found for historical rollout:', {
+                                    historyId: history._id,
+                                    hasS3Url: !!s3Url,
+                                    cachedRollouts: recentRolloutsWithData.length,
+                                    episodeLength: result.episodeLength,
+                                    totalReward: result.totalReward,
+                                  })
+                                  alert(
+                                    'This rollout only has summary data. Full step data is not available.\n\n' +
+                                    'This may happen if:\n' +
+                                    '• The rollout was saved before S3 storage was enabled\n' +
+                                    '• The rollout data was deleted from storage\n' +
+                                    '• The page was refreshed (in-memory cache cleared)\n\n' +
+                                    'Run a new rollout to see full data, or check if this rollout is in your recent rollouts.'
+                                  )
+                                }
+                              } else if (hasSteps) {
+                                // Has full step data in history - use it directly
+                                setSelectedHistoryId(history._id)
+                                setRolloutResult(result)
+                                setCurrentStepIndex(0)
+                                setIsPlaying(false)
+                                if (result.steps.length > 0 && onStepChange) {
+                                  onStepChange({ agents: result.steps[0].state.agents })
+                                }
+                                // Switch to rollout preview tab to show the data
+                                setActiveTab('rollout')
+                              }
+                            }}
+                          >
+                            {comparisonMode && (
+                              <td className="px-2 py-2 text-center">
+                                <input
+                                  type="checkbox"
+                                  checked={isCompareSelected}
+                                  onChange={() => {}}
+                                  className="w-3 h-3"
+                                />
+                              </td>
+                            )}
+                            <td className="px-3 py-2 text-muted-foreground">
+                              {new Date(history.createdAt).toLocaleTimeString()}
+                            </td>
+                            <td className="px-3 py-2 capitalize">{history.policy}</td>
+                            <td className="px-3 py-2 text-center">
+                              <span className={result?.success ? 'text-green-600' : 'text-red-600'}>
+                                {result?.success ? '✓' : '✗'}
+                              </span>
+                            </td>
+                            <td className={`px-3 py-2 text-right font-mono ${(result?.totalReward || 0) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                              {result?.totalReward?.toFixed(2) || '-'}
+                            </td>
+                            <td className="px-3 py-2 text-right font-mono">
+                              {result?.episodeLength || (result as any)?._metadata?.totalSteps || '-'}
+                            </td>
+                            <td className="px-3 py-2 text-center">
+                              {isSelected && <span className="text-primary">●</span>}
+                              {isSummaryOnly && <span className="text-muted-foreground text-[10px]">sum</span>}
+                            </td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
                 </div>
               </div>
             )}
@@ -863,107 +1381,13 @@ export function StudioBottomPanel({
         {activeTab === 'code' && <CodeViewTab envSpec={envSpec} />}
 
         {activeTab === 'analysis' && (
-          <div className="p-4 h-full overflow-y-auto space-y-6">
-            {!rolloutResult ? (
-              <div className="flex items-center justify-center h-full text-muted-foreground">
-                <div className="text-center">
-                  <p className="text-sm mb-2">Run a rollout to see RL analysis</p>
-                  <p className="text-xs">
-                    The analysis tab provides scientific insights into agent behavior
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <>
-                {/* Reward Decomposition */}
-                <div className="bg-card border border-border rounded-lg p-4">
-                  <RewardDecompositionHeatmap
-                    rolloutSteps={rolloutResult.steps}
-                    envSpec={envSpec}
-                  />
-                </div>
-
-                {/* Trajectory Path */}
-                <div className="bg-card border border-border rounded-lg p-4">
-                  <TrajectoryPathVisualizer rolloutSteps={rolloutResult.steps} envSpec={envSpec} />
-                </div>
-
-                {/* Policy Entropy */}
-                {rolloutHistory && rolloutHistory.length > 0 && (
-                  <div className="bg-card border border-border rounded-lg p-4">
-                    <div className="mb-2 text-xs text-muted-foreground">
-                      Note: Policy entropy analysis requires full step data. Summary-only rollouts
-                      will be skipped.
-                    </div>
-                    <PolicyEntropyChart
-                      rollouts={rolloutHistory
-                        .slice(0, 10)
-                        .filter((h) => {
-                          // Only use rollouts with actual step data (not summary-only)
-                          const result = h?.result
-                          return (
-                            result &&
-                            result.steps &&
-                            Array.isArray(result.steps) &&
-                            result.steps.length > 0 &&
-                            result._metadata?.hasFullData !== false
-                          )
-                        })
-                        .map((h) =>
-                          (h.result.steps || [])
-                            .filter((s: any) => s && s.state && s.action !== undefined)
-                            .map((s: any) => ({
-                              state: s.state || {},
-                              action: s.action,
-                              reward: s.reward || 0,
-                              done: s.done || false,
-                            }))
-                        )
-                        .filter((rollout) => rollout.length > 0)}
-                      envSpec={envSpec}
-                    />
-                  </div>
-                )}
-
-                {/* Termination Analysis */}
-                {rolloutHistory && rolloutHistory.length > 1 && (
-                  <div className="bg-card border border-border rounded-lg p-4">
-                    <div className="mb-2 text-xs text-muted-foreground">
-                      Note: Termination analysis requires full step data. Summary-only rollouts will
-                      be skipped.
-                    </div>
-                    <TerminationAnalysisChart
-                      rollouts={rolloutHistory
-                        .slice(0, 20)
-                        .filter((h) => {
-                          // Only use rollouts with actual step data (not summary-only)
-                          const result = h?.result
-                          return (
-                            result &&
-                            result.steps &&
-                            Array.isArray(result.steps) &&
-                            result.steps.length > 0 &&
-                            result._metadata?.hasFullData !== false
-                          )
-                        })
-                        .map((h) =>
-                          (h.result.steps || [])
-                            .filter((s: any) => s && s.state && s.action !== undefined)
-                            .map((s: any) => ({
-                              state: s.state || {},
-                              action: s.action,
-                              reward: s.reward || 0,
-                              done: s.done || false,
-                            }))
-                        )
-                        .filter((rollout) => rollout.length > 0)}
-                      envSpec={envSpec}
-                    />
-                  </div>
-                )}
-              </>
-            )}
-          </div>
+          <RLAnalysisTab
+            rolloutResult={rolloutResult}
+            rolloutHistory={rolloutHistory}
+            recentRolloutsWithData={recentRolloutsWithData}
+            envSpec={envSpec}
+            policy={policy}
+          />
         )}
       </div>
     </div>

--- a/app/components/StudioPropertiesPanel.tsx
+++ b/app/components/StudioPropertiesPanel.tsx
@@ -1,8 +1,14 @@
 import { useState, useEffect } from 'react'
-import { EnvSpec, GeometrySpec } from '~/lib/envSpec'
+import { EnvSpec, EnvType, ActionSpaceSpec, DynamicsSpec } from '~/lib/envSpec'
 import { SceneGraphManager } from '~/lib/sceneGraph'
 import { RuleEditor } from './RuleEditor'
-import { GeometryEditor } from './GeometryEditor'
+import { ValidationPanel } from './ValidationPanel'
+import {
+  validateActionSpace,
+  validateDynamics,
+  getRecommendedActionSpace,
+  getRecommendedDynamics,
+} from '~/lib/actionSpaceValidation'
 
 type EditingMode = 'structure' | 'actions' | 'rewards' | 'episode' | 'code'
 
@@ -20,18 +26,6 @@ export function StudioPropertiesPanel({
   sceneGraph,
 }: StudioPropertiesPanelProps) {
   const [mode, setMode] = useState<EditingMode>('structure')
-  const [showGeometryEditor, setShowGeometryEditor] = useState(false)
-
-  // Listen for geometry editor open event
-  useEffect(() => {
-    const handleOpenGeometryEditor = () => {
-      setShowGeometryEditor(true)
-    }
-    window.addEventListener('openGeometryEditor' as any, handleOpenGeometryEditor)
-    return () => {
-      window.removeEventListener('openGeometryEditor' as any, handleOpenGeometryEditor)
-    }
-  }, [])
 
   const modes: { id: EditingMode; label: string }[] = [
     { id: 'structure', label: 'Structure' },
@@ -84,23 +78,6 @@ export function StudioPropertiesPanel({
 
         {mode === 'code' && <CodeMode envSpec={envSpec} onSpecChange={onSpecChange} />}
       </div>
-
-      {/* Geometry Editor Modal */}
-      {showGeometryEditor && (
-        <GeometryEditor
-          envSpec={envSpec}
-          onGeometryChange={(geometry: GeometrySpec) => {
-            onSpecChange({
-              ...envSpec,
-              world: {
-                ...envSpec.world,
-                geometry,
-              },
-            })
-          }}
-          onClose={() => setShowGeometryEditor(false)}
-        />
-      )}
     </div>
   )
 }
@@ -264,22 +241,6 @@ function StructureMode({ envSpec, onSpecChange, selectedObjectId }: StudioProper
           <div className="text-xs text-muted-foreground">
             Click cells in the canvas to place objects
           </div>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium mb-2">Custom Geometry</label>
-          <button
-            onClick={() => {
-              const event = new CustomEvent('openGeometryEditor')
-              window.dispatchEvent(event)
-            }}
-            className="w-full px-3 py-2 text-sm border border-border rounded hover:bg-muted"
-          >
-            Edit Geometry (Polyline Drawing)
-          </button>
-          <p className="text-xs text-muted-foreground mt-1">
-            Define custom walkable/non-walkable regions
-          </p>
         </div>
       </div>
     )
@@ -460,22 +421,6 @@ function StructureMode({ envSpec, onSpecChange, selectedObjectId }: StudioProper
             />
           </div>
         </div>
-
-        <div>
-          <label className="block text-sm font-medium mb-2">Custom Geometry</label>
-          <button
-            onClick={() => {
-              const event = new CustomEvent('openGeometryEditor')
-              window.dispatchEvent(event)
-            }}
-            className="w-full px-3 py-2 text-sm border border-border rounded hover:bg-muted"
-          >
-            Edit Geometry (Polyline Drawing)
-          </button>
-          <p className="text-xs text-muted-foreground mt-1">
-            Define custom walkable/non-walkable regions
-          </p>
-        </div>
       </div>
     )
   }
@@ -499,35 +444,170 @@ function StructureMode({ envSpec, onSpecChange, selectedObjectId }: StudioProper
 }
 
 function ActionsMode({ envSpec, onSpecChange }: StudioPropertiesPanelProps) {
-  const actionSpace = envSpec?.actionSpace || {
-    type: 'discrete',
-    actions: ['up', 'down', 'left', 'right'],
+  const envType: EnvType = envSpec?.envType || (envSpec?.world?.coordinateSystem === 'grid' ? 'grid' : 'continuous2d')
+  const actionSpace = envSpec?.actionSpace || getRecommendedActionSpace(envType)
+  const dynamics = envSpec?.agents?.[0]?.dynamics || getRecommendedDynamics(envType)
+  const [useCustom, setUseCustom] = useState(false)
+
+  // Check if current action space matches recommended
+  useEffect(() => {
+    const recommended = getRecommendedActionSpace(envType)
+    const isRecommended =
+      actionSpace.type === recommended.type &&
+      (recommended.type === 'discrete'
+        ? JSON.stringify(actionSpace.actions?.sort()) === JSON.stringify(recommended.actions?.sort())
+        : actionSpace.dimensions === recommended.dimensions &&
+          JSON.stringify(actionSpace.range) === JSON.stringify(recommended.range))
+    setUseCustom(!isRecommended)
+  }, [envType, actionSpace])
+
+  // Real-time validation
+  const actionSpaceValidation = validateActionSpace(actionSpace, envType, dynamics)
+  const dynamicsValidation = validateDynamics(dynamics, actionSpace)
+
+  const handleActionSpaceChange = (newActionSpace: ActionSpaceSpec) => {
+    onSpecChange({
+      ...envSpec,
+      actionSpace: newActionSpace,
+    })
+  }
+
+  const handleDynamicsChange = (newDynamics: DynamicsSpec) => {
+    // Update all agents' dynamics
+    const updatedAgents = envSpec.agents.map((agent) => ({
+      ...agent,
+      dynamics: newDynamics,
+    }))
+    onSpecChange({
+      ...envSpec,
+      agents: updatedAgents,
+    })
+  }
+
+  const handleUseRecommended = () => {
+    const recommended = getRecommendedActionSpace(envType)
+    const recommendedDynamics = getRecommendedDynamics(envType)
+    handleActionSpaceChange(recommended)
+    handleDynamicsChange(recommendedDynamics)
+    setUseCustom(false)
   }
 
   return (
     <div className="space-y-4">
+      {/* Environment Type Badge */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="px-2 py-1 text-xs font-medium bg-primary/10 text-primary rounded">
+            {envType === 'grid' ? 'Grid' : envType === 'continuous2d' ? 'Continuous 2D' : envType}
+          </span>
+        </div>
+        {useCustom && (
+          <button
+            onClick={handleUseRecommended}
+            className="px-2 py-1 text-xs bg-muted hover:bg-muted/80 rounded border border-border"
+          >
+            Use Recommended
+          </button>
+        )}
+      </div>
+
+      {/* Action Space Configuration */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <label className="block text-sm font-medium">Action Space</label>
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={useCustom}
+              onChange={(e) => setUseCustom(e.target.checked)}
+              className="rounded"
+            />
+            <span>Custom</span>
+          </label>
+        </div>
+
+        {envType === 'grid' ? (
+          <GridActionsConfig
+            actionSpace={actionSpace}
+            useCustom={useCustom}
+            onActionSpaceChange={handleActionSpaceChange}
+          />
+        ) : envType === 'continuous2d' ? (
+          <ContinuousActionsConfig
+            actionSpace={actionSpace}
+            useCustom={useCustom}
+            onActionSpaceChange={handleActionSpaceChange}
+          />
+        ) : (
+          <GenericActionsConfig
+            actionSpace={actionSpace}
+            onActionSpaceChange={handleActionSpaceChange}
+          />
+        )}
+
+        <ValidationPanel validation={actionSpaceValidation} title="Action Space" />
+      </div>
+
+      {/* Dynamics Configuration */}
+      <div className="space-y-3">
+        <label className="block text-sm font-medium">Dynamics</label>
+        <DynamicsConfig
+          dynamics={dynamics}
+          envType={envType}
+          actionSpace={actionSpace}
+          onDynamicsChange={handleDynamicsChange}
+        />
+        <ValidationPanel validation={dynamicsValidation} title="Dynamics" />
+      </div>
+    </div>
+  )
+}
+
+// Grid Actions Configuration Component
+function GridActionsConfig({
+  actionSpace,
+  useCustom,
+  onActionSpaceChange,
+}: {
+  actionSpace: ActionSpaceSpec
+  useCustom: boolean
+  onActionSpaceChange: (actionSpace: ActionSpaceSpec) => void
+}) {
+  if (!useCustom) {
+    return (
+      <div className="bg-muted/30 border border-border rounded-lg p-3">
+        <div className="text-sm text-muted-foreground">
+          <p className="font-medium mb-1">Recommended: Discrete Actions</p>
+          <p className="text-xs">
+            Actions: {actionSpace.type === 'discrete' ? actionSpace.actions?.join(', ') : 'N/A'}
+          </p>
+          <p className="text-xs mt-1">Enable "Custom" to modify</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
       <div>
-        <label className="block text-sm font-medium mb-2">Action Space Type</label>
+        <label className="block text-xs font-medium mb-1">Action Space Type</label>
         <select
           value={actionSpace.type || 'discrete'}
           onChange={(e) => {
-            onSpecChange({
-              ...envSpec,
-              actionSpace: {
-                type: e.target.value,
-                actions:
-                  e.target.value === 'discrete' ? ['up', 'down', 'left', 'right'] : undefined,
-                bounds:
-                  e.target.value === 'continuous'
-                    ? [
-                        [-1, 1],
-                        [-1, 1],
-                      ]
-                    : undefined,
-              },
-            })
+            if (e.target.value === 'discrete') {
+              onActionSpaceChange({
+                type: 'discrete',
+                actions: actionSpace.type === 'discrete' ? actionSpace.actions || [] : ['up', 'down', 'left', 'right'],
+              })
+            } else {
+              onActionSpaceChange({
+                type: 'continuous',
+                dimensions: 2,
+                range: [-1, 1],
+              })
+            }
           }}
-          className="w-full px-2 py-1 border border-border rounded text-sm"
+          className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
         >
           <option value="discrete">Discrete</option>
           <option value="continuous">Continuous</option>
@@ -536,7 +616,18 @@ function ActionsMode({ envSpec, onSpecChange }: StudioPropertiesPanelProps) {
 
       {actionSpace.type === 'discrete' && (
         <div>
-          <label className="block text-sm font-medium mb-2">Actions</label>
+          <div className="flex items-center justify-between mb-1">
+            <label className="block text-xs font-medium">Actions</label>
+            <button
+              onClick={() => {
+                const newActions = [...(actionSpace.actions || []), 'new_action']
+                onActionSpaceChange({ ...actionSpace, actions: newActions })
+              }}
+              className="px-2 py-0.5 text-xs bg-primary text-primary-foreground rounded hover:opacity-90"
+            >
+              + Add
+            </button>
+          </div>
           <div className="space-y-1">
             {actionSpace.actions?.map((action: string, i: number) => (
               <div key={i} className="flex items-center gap-2">
@@ -546,13 +637,234 @@ function ActionsMode({ envSpec, onSpecChange }: StudioPropertiesPanelProps) {
                   onChange={(e) => {
                     const newActions = [...(actionSpace.actions || [])]
                     newActions[i] = e.target.value
-                    onSpecChange({
-                      ...envSpec,
-                      actionSpace: { ...actionSpace, actions: newActions },
-                    })
+                    onActionSpaceChange({ ...actionSpace, actions: newActions })
                   }}
-                  className="flex-1 px-2 py-1 border border-border rounded text-sm"
+                  className="flex-1 px-2 py-1 border border-border rounded text-sm bg-background"
+                  placeholder="action_name"
                 />
+                {actionSpace.actions && actionSpace.actions.length > 1 && (
+                  <button
+                    onClick={() => {
+                      const newActions = actionSpace.actions.filter((_, idx) => idx !== i)
+                      onActionSpaceChange({ ...actionSpace, actions: newActions })
+                    }}
+                    className="px-2 py-1 text-xs text-destructive hover:bg-destructive/10 rounded"
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {actionSpace.type === 'continuous' && (
+        <div className="space-y-2">
+          <div>
+            <label className="block text-xs font-medium mb-1">Dimensions</label>
+            <input
+              type="number"
+              min="1"
+              max="10"
+              value={actionSpace.dimensions || 2}
+              onChange={(e) => {
+                const dims = parseInt(e.target.value, 10) || 2
+                onActionSpaceChange({
+                  ...actionSpace,
+                  dimensions: dims,
+                })
+              }}
+              className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1">Range</label>
+            <div className="flex gap-2">
+              <input
+                type="number"
+                step="0.1"
+                value={actionSpace.range?.[0] ?? -1}
+                onChange={(e) => {
+                  const min = parseFloat(e.target.value) || -1
+                  onActionSpaceChange({
+                    ...actionSpace,
+                    range: [min, actionSpace.range?.[1] ?? 1],
+                  })
+                }}
+                className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+                placeholder="Min"
+              />
+              <input
+                type="number"
+                step="0.1"
+                value={actionSpace.range?.[1] ?? 1}
+                onChange={(e) => {
+                  const max = parseFloat(e.target.value) || 1
+                  onActionSpaceChange({
+                    ...actionSpace,
+                    range: [actionSpace.range?.[0] ?? -1, max],
+                  })
+                }}
+                className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+                placeholder="Max"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Continuous Actions Configuration Component
+function ContinuousActionsConfig({
+  actionSpace,
+  useCustom,
+  onActionSpaceChange,
+}: {
+  actionSpace: ActionSpaceSpec
+  useCustom: boolean
+  onActionSpaceChange: (actionSpace: ActionSpaceSpec) => void
+}) {
+  if (!useCustom) {
+    return (
+      <div className="bg-muted/30 border border-border rounded-lg p-3">
+        <div className="text-sm text-muted-foreground">
+          <p className="font-medium mb-1">Recommended: Continuous Actions</p>
+          <p className="text-xs">
+            Dimensions: {actionSpace.type === 'continuous' ? actionSpace.dimensions : 'N/A'}, Range:{' '}
+            {actionSpace.type === 'continuous' ? `[${actionSpace.range?.[0]}, ${actionSpace.range?.[1]}]` : 'N/A'}
+          </p>
+          <p className="text-xs mt-1">Enable "Custom" to modify</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-xs font-medium mb-1">Action Space Type</label>
+        <select
+          value={actionSpace.type || 'continuous'}
+          onChange={(e) => {
+            if (e.target.value === 'continuous') {
+              onActionSpaceChange({
+                type: 'continuous',
+                dimensions: actionSpace.type === 'continuous' ? actionSpace.dimensions || 2 : 2,
+                range: actionSpace.type === 'continuous' ? actionSpace.range || [-1, 1] : [-1, 1],
+              })
+            } else {
+              onActionSpaceChange({
+                type: 'discrete',
+                actions: ['up', 'down', 'left', 'right'],
+              })
+            }
+          }}
+          className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+        >
+          <option value="continuous">Continuous</option>
+          <option value="discrete">Discrete</option>
+        </select>
+      </div>
+
+      {actionSpace.type === 'continuous' && (
+        <div className="space-y-2">
+          <div>
+            <label className="block text-xs font-medium mb-1">Dimensions</label>
+            <input
+              type="number"
+              min="1"
+              max="10"
+              value={actionSpace.dimensions || 2}
+              onChange={(e) => {
+                const dims = parseInt(e.target.value, 10) || 2
+                onActionSpaceChange({
+                  ...actionSpace,
+                  dimensions: dims,
+                })
+              }}
+              className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+            />
+            <p className="text-xs text-muted-foreground mt-1">Typically 2 for X, Y velocity</p>
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1">Range</label>
+            <div className="flex gap-2">
+              <input
+                type="number"
+                step="0.1"
+                value={actionSpace.range?.[0] ?? -1}
+                onChange={(e) => {
+                  const min = parseFloat(e.target.value) || -1
+                  onActionSpaceChange({
+                    ...actionSpace,
+                    range: [min, actionSpace.range?.[1] ?? 1],
+                  })
+                }}
+                className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+                placeholder="Min"
+              />
+              <input
+                type="number"
+                step="0.1"
+                value={actionSpace.range?.[1] ?? 1}
+                onChange={(e) => {
+                  const max = parseFloat(e.target.value) || 1
+                  onActionSpaceChange({
+                    ...actionSpace,
+                    range: [actionSpace.range?.[0] ?? -1, max],
+                  })
+                }}
+                className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+                placeholder="Max"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">Normalized velocity range (recommended: -1 to 1)</p>
+          </div>
+        </div>
+      )}
+
+      {actionSpace.type === 'discrete' && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label className="block text-xs font-medium">Actions</label>
+            <button
+              onClick={() => {
+                const newActions = [...(actionSpace.actions || []), 'new_action']
+                onActionSpaceChange({ ...actionSpace, actions: newActions })
+              }}
+              className="px-2 py-0.5 text-xs bg-primary text-primary-foreground rounded hover:opacity-90"
+            >
+              + Add
+            </button>
+          </div>
+          <div className="space-y-1">
+            {actionSpace.actions?.map((action: string, i: number) => (
+              <div key={i} className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={action}
+                  onChange={(e) => {
+                    const newActions = [...(actionSpace.actions || [])]
+                    newActions[i] = e.target.value
+                    onActionSpaceChange({ ...actionSpace, actions: newActions })
+                  }}
+                  className="flex-1 px-2 py-1 border border-border rounded text-sm bg-background"
+                  placeholder="action_name"
+                />
+                {actionSpace.actions && actionSpace.actions.length > 1 && (
+                  <button
+                    onClick={() => {
+                      const newActions = actionSpace.actions.filter((_, idx) => idx !== i)
+                      onActionSpaceChange({ ...actionSpace, actions: newActions })
+                    }}
+                    className="px-2 py-1 text-xs text-destructive hover:bg-destructive/10 rounded"
+                  >
+                    ×
+                  </button>
+                )}
               </div>
             ))}
           </div>
@@ -562,157 +874,452 @@ function ActionsMode({ envSpec, onSpecChange }: StudioPropertiesPanelProps) {
   )
 }
 
+// Generic Actions Configuration (fallback)
+function GenericActionsConfig({
+  actionSpace,
+  onActionSpaceChange,
+}: {
+  actionSpace: ActionSpaceSpec
+  onActionSpaceChange: (actionSpace: ActionSpaceSpec) => void
+}) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-xs font-medium mb-1">Action Space Type</label>
+        <select
+          value={actionSpace.type || 'discrete'}
+          onChange={(e) => {
+            if (e.target.value === 'discrete') {
+              onActionSpaceChange({
+                type: 'discrete',
+                actions: actionSpace.type === 'discrete' ? actionSpace.actions || [] : ['up', 'down', 'left', 'right'],
+              })
+            } else {
+              onActionSpaceChange({
+                type: 'continuous',
+                dimensions: 2,
+                range: [-1, 1],
+              })
+            }
+          }}
+          className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+        >
+          <option value="discrete">Discrete</option>
+          <option value="continuous">Continuous</option>
+        </select>
+      </div>
+
+      {actionSpace.type === 'discrete' && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label className="block text-xs font-medium">Actions</label>
+            <button
+              onClick={() => {
+                const newActions = [...(actionSpace.actions || []), 'new_action']
+                onActionSpaceChange({ ...actionSpace, actions: newActions })
+              }}
+              className="px-2 py-0.5 text-xs bg-primary text-primary-foreground rounded hover:opacity-90"
+            >
+              + Add
+            </button>
+          </div>
+          <div className="space-y-1">
+            {actionSpace.actions?.map((action: string, i: number) => (
+              <div key={i} className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={action}
+                  onChange={(e) => {
+                    const newActions = [...(actionSpace.actions || [])]
+                    newActions[i] = e.target.value
+                    onActionSpaceChange({ ...actionSpace, actions: newActions })
+                  }}
+                  className="flex-1 px-2 py-1 border border-border rounded text-sm bg-background"
+                />
+                {actionSpace.actions && actionSpace.actions.length > 1 && (
+                  <button
+                    onClick={() => {
+                      const newActions = actionSpace.actions.filter((_, idx) => idx !== i)
+                      onActionSpaceChange({ ...actionSpace, actions: newActions })
+                    }}
+                    className="px-2 py-1 text-xs text-destructive hover:bg-destructive/10 rounded"
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {actionSpace.type === 'continuous' && (
+        <div className="space-y-2">
+          <div>
+            <label className="block text-xs font-medium mb-1">Dimensions</label>
+            <input
+              type="number"
+              min="1"
+              max="10"
+              value={actionSpace.dimensions || 2}
+              onChange={(e) => {
+                const dims = parseInt(e.target.value, 10) || 2
+                onActionSpaceChange({
+                  ...actionSpace,
+                  dimensions: dims,
+                })
+              }}
+              className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1">Range</label>
+            <div className="flex gap-2">
+              <input
+                type="number"
+                step="0.1"
+                value={actionSpace.range?.[0] ?? -1}
+                onChange={(e) => {
+                  const min = parseFloat(e.target.value) || -1
+                  onActionSpaceChange({
+                    ...actionSpace,
+                    range: [min, actionSpace.range?.[1] ?? 1],
+                  })
+                }}
+                className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+              />
+              <input
+                type="number"
+                step="0.1"
+                value={actionSpace.range?.[1] ?? 1}
+                onChange={(e) => {
+                  const max = parseFloat(e.target.value) || 1
+                  onActionSpaceChange({
+                    ...actionSpace,
+                    range: [actionSpace.range?.[0] ?? -1, max],
+                  })
+                }}
+                className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Dynamics Configuration Component
+function DynamicsConfig({
+  dynamics,
+  envType,
+  actionSpace,
+  onDynamicsChange,
+}: {
+  dynamics: DynamicsSpec | undefined
+  envType: EnvType
+  actionSpace: ActionSpaceSpec
+  onDynamicsChange: (dynamics: DynamicsSpec) => void
+}) {
+  const currentDynamics = dynamics || getRecommendedDynamics(envType)
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className="block text-xs font-medium mb-1">Dynamics Type</label>
+        <select
+          value={currentDynamics.type}
+          onChange={(e) => {
+            const type = e.target.value
+            if (type === 'grid-step') {
+              onDynamicsChange({ type: 'grid-step' })
+            } else if (type === 'continuous-velocity') {
+              onDynamicsChange({ type: 'continuous-velocity', maxSpeed: 0.1 })
+            } else if (type === 'car-like') {
+              onDynamicsChange({ type: 'car-like', maxSpeed: 0.1, turnRate: 0.1 })
+            }
+          }}
+          className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+        >
+          <option value="grid-step">Grid Step</option>
+          <option value="continuous-velocity">Continuous Velocity</option>
+          <option value="car-like">Car-like</option>
+        </select>
+      </div>
+
+      {currentDynamics.type === 'continuous-velocity' && (
+        <div>
+          <label className="block text-xs font-medium mb-1">Max Speed</label>
+          <input
+            type="number"
+            step="0.01"
+            min="0.01"
+            max="10"
+            value={currentDynamics.maxSpeed || 0.1}
+            onChange={(e) => {
+              const maxSpeed = parseFloat(e.target.value) || 0.1
+              onDynamicsChange({ type: 'continuous-velocity', maxSpeed })
+            }}
+            className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+          />
+          <p className="text-xs text-muted-foreground mt-1">Maximum velocity per step</p>
+        </div>
+      )}
+
+      {currentDynamics.type === 'car-like' && (
+        <div className="space-y-2">
+          <div>
+            <label className="block text-xs font-medium mb-1">Max Speed</label>
+            <input
+              type="number"
+              step="0.01"
+              min="0.01"
+              max="10"
+              value={currentDynamics.maxSpeed || 0.1}
+              onChange={(e) => {
+                const maxSpeed = parseFloat(e.target.value) || 0.1
+                onDynamicsChange({
+                  type: 'car-like',
+                  maxSpeed,
+                  turnRate: currentDynamics.type === 'car-like' ? currentDynamics.turnRate : 0.1,
+                })
+              }}
+              className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium mb-1">Turn Rate</label>
+            <input
+              type="number"
+              step="0.01"
+              min="0.01"
+              max="2"
+              value={currentDynamics.type === 'car-like' ? currentDynamics.turnRate || 0.1 : 0.1}
+              onChange={(e) => {
+                const turnRate = parseFloat(e.target.value) || 0.1
+                onDynamicsChange({
+                  type: 'car-like',
+                  maxSpeed: currentDynamics.type === 'car-like' ? currentDynamics.maxSpeed : 0.1,
+                  turnRate,
+                })
+              }}
+              className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+            />
+          </div>
+        </div>
+      )}
+
+      {currentDynamics.type === 'grid-step' && (
+        <div className="text-xs text-muted-foreground">
+          <p>Moves one cell per action (matches grid cell size)</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function RewardsMode({ envSpec, onSpecChange }: StudioPropertiesPanelProps) {
-  const reward = envSpec?.reward || { rules: [] }
+  const rules = envSpec?.rules?.rewards || []
 
-  const commonConditions = [
-    { type: 'goal', label: 'Goal Reached', default: 10 },
-    { type: 'trap', label: 'Trap Hit', default: -10 },
-    { type: 'step', label: 'Per Step', default: -0.1 },
-    { type: 'key', label: 'Key Collected', default: 1 },
-  ]
-
-  const addRule = (conditionType: string, defaultValue: number) => {
+  const addRule = () => {
+    const newRule = {
+      id: `reward_${Date.now()}`,
+      condition: { type: 'timeout', steps: 1 },
+      reward: 0,
+      shaping: false,
+    }
     onSpecChange({
       ...envSpec,
-      reward: {
-        ...reward,
-        rules: [
-          ...(reward.rules || []),
-          { condition: { type: conditionType }, value: defaultValue },
-        ],
+      rules: {
+        ...envSpec.rules,
+        rewards: [...rules, newRule],
       },
     })
+  }
+
+  const removeRule = (ruleId: string) => {
+    const newRules = rules.filter((r: any) => r.id !== ruleId)
+    onSpecChange({
+      ...envSpec,
+      rules: {
+        ...envSpec.rules,
+        rewards: newRules,
+      },
+    })
+  }
+
+  const updateRule = (ruleId: string, updates: any) => {
+    const newRules = rules.map((r: any) => (r.id === ruleId ? { ...r, ...updates } : r))
+    onSpecChange({
+      ...envSpec,
+      rules: {
+        ...envSpec.rules,
+        rewards: newRules,
+      },
+    })
+  }
+
+  const getConditionLabel = (condition: any) => {
+    if (!condition) return 'Unknown'
+    if (condition.type === 'timeout') return `Timeout (Steps)`
+    if (condition.type === 'reach_goal') return 'Goal Reached'
+    if (condition.type === 'hit_trap') return 'Trap Hit'
+    if (condition.type === 'step') return 'Per Step'
+    if (condition.type === 'collect_key') return 'Key Collected'
+    return condition.type || 'Custom'
+  }
+
+  const getTotalReward = () => {
+    if (rules.length === 0) return 0
+    // For timeout conditions, calculate based on steps
+    return rules.reduce((sum: number, rule: any) => {
+      if (rule.condition?.type === 'timeout' && rule.condition?.steps) {
+        return sum + rule.reward * rule.condition.steps
+      }
+      return sum + rule.reward
+    }, 0)
   }
 
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <label className="text-sm font-medium">Reward Rules</label>
-        <div className="flex gap-1">
-          {commonConditions.map((cond) => (
-            <button
-              key={cond.type}
-              onClick={() => addRule(cond.type, cond.default)}
-              className="text-xs px-2 py-1 border border-border rounded hover:bg-muted"
-              title={cond.label}
-            >
-              + {cond.label}
-            </button>
-          ))}
-        </div>
+        <button
+          onClick={addRule}
+          className="text-xs px-3 py-1 bg-primary text-primary-foreground rounded hover:opacity-90"
+        >
+          + Add Rule
+        </button>
       </div>
 
-      <div className="space-y-2 max-h-64 overflow-y-auto">
-        {reward.rules?.map((rule: any, i: number) => {
-          const conditionLabel =
-            commonConditions.find((c) => c.type === rule.condition?.type)?.label ||
-            rule.condition?.type ||
-            'unknown'
-
-          return (
-            <div key={i} className="p-2 border border-border rounded bg-muted/50">
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-xs font-medium">{conditionLabel}</span>
+      <div className="space-y-2 max-h-96 overflow-y-auto">
+        {rules.length === 0 ? (
+          <div className="text-xs text-muted-foreground p-4 text-center border border-border rounded">
+            No reward rules defined. Click "+ Add Rule" to add a rule.
+          </div>
+        ) : (
+          rules.map((rule: any) => (
+            <div key={rule.id} className="p-3 border border-border rounded bg-muted/30">
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-xs font-medium">Reward Rule</span>
                 <button
-                  onClick={() => {
-                    const newRules = [...(reward.rules || [])]
-                    newRules.splice(i, 1)
-                    onSpecChange({
-                      ...envSpec,
-                      reward: { ...reward, rules: newRules },
-                    })
-                  }}
+                  onClick={() => removeRule(rule.id)}
                   className="text-xs text-red-600 hover:text-red-800"
                 >
                   ×
                 </button>
               </div>
-              <div className="space-y-1">
+              <div className="space-y-2">
                 <div className="flex items-center gap-2">
-                  <label className="text-xs text-muted-foreground w-16">Condition:</label>
+                  <label className="text-xs text-muted-foreground w-12">IF:</label>
                   <select
                     value={rule.condition?.type || ''}
                     onChange={(e) => {
-                      const newRules = [...(reward.rules || [])]
-                      const defaultVal =
-                        commonConditions.find((c) => c.type === e.target.value)?.default || 0
-                      newRules[i] = {
-                        ...rule,
-                        condition: { type: e.target.value },
-                        value: defaultVal,
+                      const conditionType = e.target.value
+                      let newCondition: any = { type: conditionType }
+                      
+                      // Set default steps for timeout
+                      if (conditionType === 'timeout') {
+                        newCondition.steps = rule.condition?.steps || 1
                       }
-                      onSpecChange({
-                        ...envSpec,
-                        reward: { ...reward, rules: newRules },
-                      })
+                      
+                      updateRule(rule.id, { condition: newCondition })
                     }}
-                    className="flex-1 px-2 py-1 border border-border rounded text-xs"
+                    className="flex-1 px-2 py-1 border border-border rounded text-sm bg-background"
                   >
-                    <option value="">Select condition...</option>
-                    {commonConditions.map((cond) => (
-                      <option key={cond.type} value={cond.type}>
-                        {cond.label}
-                      </option>
-                    ))}
+                    <option value="timeout">Timeout (Steps)</option>
+                    <option value="reach_goal">Goal Reached</option>
+                    <option value="hit_trap">Trap Hit</option>
+                    <option value="step">Per Step</option>
+                    <option value="collect_key">Key Collected</option>
                     <option value="custom">Custom</option>
                   </select>
                 </div>
+                
+                {rule.condition?.type === 'timeout' && (
+                  <div className="flex items-center gap-2">
+                    <label className="text-xs text-muted-foreground w-12">Steps:</label>
+                    <input
+                      type="number"
+                      min="1"
+                      value={rule.condition?.steps || 1}
+                      onChange={(e) => {
+                        updateRule(rule.id, {
+                          condition: { ...rule.condition, steps: parseInt(e.target.value, 10) || 1 },
+                        })
+                      }}
+                      className="flex-1 px-2 py-1 border border-border rounded text-sm bg-background"
+                    />
+                  </div>
+                )}
+
                 <div className="flex items-center gap-2">
-                  <label className="text-xs text-muted-foreground w-16">Value:</label>
+                  <label className="text-xs text-muted-foreground w-12">Reward:</label>
                   <input
                     type="number"
                     step="0.1"
-                    value={rule.value ?? 0}
+                    value={rule.reward ?? 0}
                     onChange={(e) => {
-                      const newRules = [...(reward.rules || [])]
-                      newRules[i] = { ...rule, value: parseFloat(e.target.value) || 0 }
-                      onSpecChange({
-                        ...envSpec,
-                        reward: { ...reward, rules: newRules },
-                      })
+                      updateRule(rule.id, { reward: parseFloat(e.target.value) || 0 })
                     }}
-                    className="flex-1 px-2 py-1 border border-border rounded text-xs"
+                    className="flex-1 px-2 py-1 border border-border rounded text-sm bg-background"
                   />
                   <span
-                    className={`text-xs font-mono w-12 text-right ${rule.value >= 0 ? 'text-green-600' : 'text-red-600'}`}
+                    className={`text-xs font-mono w-16 text-right ${rule.reward >= 0 ? 'text-green-600' : 'text-red-600'}`}
                   >
-                    {rule.value >= 0 ? '+' : ''}
-                    {rule.value}
+                    {rule.reward >= 0 ? '+' : ''}
+                    {rule.reward}
                   </span>
                 </div>
+
+                <label className="flex items-center gap-2 text-xs">
+                  <input
+                    type="checkbox"
+                    checked={rule.shaping || false}
+                    onChange={(e) => {
+                      updateRule(rule.id, { shaping: e.target.checked })
+                    }}
+                    className="rounded"
+                  />
+                  <span>Reward shaping (dense reward signal)</span>
+                </label>
               </div>
             </div>
-          )
-        }) || (
-          <div className="text-xs text-muted-foreground p-4 text-center">
-            No reward rules defined. Click buttons above to add rules.
-          </div>
+          ))
         )}
       </div>
 
-      {reward.rules && reward.rules.length > 0 && (
-        <div className="pt-2 border-t border-border">
+      {rules.length > 0 && (
+        <div className="pt-3 border-t border-border">
           <div className="text-xs text-muted-foreground">
-            <div className="font-medium mb-1">Reward Summary:</div>
+            <div className="font-medium mb-1">Total Rewards:</div>
             <div className="space-y-0.5">
-              {reward.rules.map((rule: any, i: number) => {
-                const conditionLabel =
-                  commonConditions.find((c) => c.type === rule.condition?.type)?.label ||
-                  rule.condition?.type ||
-                  'unknown'
+              {rules.map((rule: any) => {
+                const conditionLabel = getConditionLabel(rule.condition)
+                const stepInfo = rule.condition?.type === 'timeout' && rule.condition?.steps
+                  ? `After ${rule.condition.steps} steps`
+                  : 'On trigger'
                 return (
-                  <div key={i} className="flex justify-between">
-                    <span>{conditionLabel}:</span>
+                  <div key={rule.id} className="flex justify-between">
+                    <span>{conditionLabel} ({stepInfo}):</span>
                     <span
-                      className={`font-mono ${rule.value >= 0 ? 'text-green-600' : 'text-red-600'}`}
+                      className={`font-mono ${rule.reward >= 0 ? 'text-green-600' : 'text-red-600'}`}
                     >
-                      {rule.value >= 0 ? '+' : ''}
-                      {rule.value}
+                      {rule.reward >= 0 ? '+' : ''}
+                      {rule.reward}
                     </span>
                   </div>
                 )
               })}
+              <div className="pt-1 mt-1 border-t border-border">
+                <div className="flex justify-between font-medium">
+                  <span>Total:</span>
+                  <span className={`font-mono ${getTotalReward() >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {getTotalReward() >= 0 ? '+' : ''}
+                    {getTotalReward().toFixed(1)}
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -724,6 +1331,14 @@ function RewardsMode({ envSpec, onSpecChange }: StudioPropertiesPanelProps) {
 function EpisodeMode({ envSpec, onSpecChange }: StudioPropertiesPanelProps) {
   const episode = envSpec?.episode || { maxSteps: 100, termination: [] }
   const curriculum = envSpec?.curriculum || { stages: [] }
+  const [maxStepsInput, setMaxStepsInput] = useState<string>('')
+
+  // Sync local state with envSpec when it changes externally
+  useEffect(() => {
+    if (episode?.maxSteps !== undefined) {
+      setMaxStepsInput(String(episode.maxSteps))
+    }
+  }, [episode?.maxSteps])
 
   return (
     <div className="space-y-6">
@@ -735,15 +1350,41 @@ function EpisodeMode({ envSpec, onSpecChange }: StudioPropertiesPanelProps) {
             <label className="block text-xs font-medium mb-1">Max Episode Length</label>
             <input
               type="number"
-              value={episode.maxSteps || 100}
+              min="1"
+              max="10000"
+              value={maxStepsInput || episode?.maxSteps || 100}
               onChange={(e) => {
-                onSpecChange({
-                  ...envSpec,
-                  episode: { ...episode, maxSteps: parseInt(e.target.value) || 100 },
-                })
+                const inputValue = e.target.value
+                setMaxStepsInput(inputValue) // Update local state immediately
+                
+                // Check if this is different from current value
+                const currentMaxSteps = episode?.maxSteps || 100
+                const newMaxSteps = parseInt(inputValue, 10)
+                
+                if (!isNaN(newMaxSteps) && newMaxSteps >= 1 && newMaxSteps <= 10000 && newMaxSteps !== currentMaxSteps) {
+                  // Update immediately for real-time preview
+                  onSpecChange({
+                    ...envSpec,
+                    episode: { ...episode, maxSteps: newMaxSteps },
+                  })
+                }
               }}
-              className="w-full px-2 py-1 border border-border rounded text-xs"
+              onBlur={(e) => {
+                // Validate and clamp on blur
+                const maxSteps = parseInt(e.target.value, 10)
+                if (isNaN(maxSteps) || maxSteps < 1 || maxSteps > 10000) {
+                  const validMaxSteps = Math.max(1, Math.min(10000, maxSteps || 100))
+                  setMaxStepsInput(String(validMaxSteps))
+                  onSpecChange({
+                    ...envSpec,
+                    episode: { ...episode, maxSteps: validMaxSteps },
+                  })
+                }
+              }}
+              className="w-full px-2 py-1 border border-border rounded text-sm bg-background"
+              placeholder="100"
             />
+            <p className="text-xs text-muted-foreground mt-1">Maximum number of steps before episode times out (1-10000)</p>
           </div>
 
           <div>
@@ -967,3 +1608,4 @@ function CodeMode({ envSpec, onSpecChange }: StudioPropertiesPanelProps) {
     </div>
   )
 }
+

--- a/app/components/TerminationAnalysisChart.tsx
+++ b/app/components/TerminationAnalysisChart.tsx
@@ -1,7 +1,6 @@
 /**
  * Termination Analysis Chart Component
- * REQUIRES Python backend - NO FALLBACKS
- * Real calculations use scipy.stats in backend
+ * Clean professional visualization of termination patterns
  */
 
 import { useEffect, useState } from 'react'
@@ -17,9 +16,6 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
 } from 'recharts'
 import { EnvSpec } from '~/lib/envSpec'
 
@@ -35,37 +31,26 @@ interface TerminationAnalysisChartProps {
   envSpec: EnvSpec
 }
 
-const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4']
-
 export function TerminationAnalysisChart({ rollouts, envSpec }: TerminationAnalysisChartProps) {
   const [analysis, setAnalysis] = useState<TerminationAnalysisMultiple | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [progress, setProgress] = useState<{ progress: number; message: string } | null>(null)
 
   useEffect(() => {
     if (rollouts.length === 0) return
 
     setLoading(true)
     setError(null)
-    setProgress(null)
 
-    // Use streaming for real-time updates
     const cleanup = analyzeMultipleTerminationsStreaming(rollouts, envSpec, {
-      onProgress: (prog, msg) => {
-        setProgress({ progress: prog, message: msg })
-      },
+      onProgress: () => {},
       onComplete: (backendAnalysis) => {
         setAnalysis(backendAnalysis)
-        setProgress(null)
         setLoading(false)
-        console.log('✅ Termination analysis complete - Real Python calculations (scipy.stats)')
       },
       onError: (err) => {
         setError(err.message)
         setLoading(false)
-        setProgress(null)
-        console.error('❌ Termination analysis failed:', err)
       },
     })
 
@@ -74,311 +59,121 @@ export function TerminationAnalysisChart({ rollouts, envSpec }: TerminationAnaly
 
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 text-muted-foreground">
-        <div className="text-sm mb-2">Running Python analysis (scipy.stats)...</div>
-        {progress && (
-          <div className="text-xs text-muted-foreground">
-            {progress.message}{' '}
-            {progress.progress > 0 && `(${Math.round(progress.progress * 100)}%)`}
-          </div>
-        )}
-        <div className="mt-4 w-64 h-2 bg-muted rounded-full overflow-hidden">
-          <div
-            className="h-full bg-primary transition-all duration-300"
-            style={{ width: `${(progress?.progress || 0) * 100}%` }}
-          />
-        </div>
+      <div className="flex items-center justify-center h-48">
+        <div className="text-sm text-muted-foreground">Analyzing terminations...</div>
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 text-destructive border border-destructive/50 rounded-lg p-4 bg-destructive/10">
-        <div className="font-semibold mb-2">❌ Backend Required</div>
-        <div className="text-sm text-center">{error}</div>
-        <div className="text-xs mt-2 text-muted-foreground">
-          Real Python calculations (scipy.stats) are required. Backend:{' '}
-          <code className="bg-muted px-1 rounded">
-            {import.meta.env.VITE_ROLLOUT_SERVICE_URL || 'http://localhost:8000'}
-          </code>
-        </div>
+      <div className="flex items-center justify-center h-48">
+        <div className="text-sm text-red-600">{error}</div>
       </div>
     )
   }
 
   if (!analysis || !analysis.top_causes || analysis.top_causes.length === 0) {
     return (
-      <div className="flex items-center justify-center h-64 text-muted-foreground">
-        No termination data available. Run multiple rollouts to see termination analysis.
+      <div className="flex items-center justify-center h-48">
+        <div className="text-sm text-muted-foreground">
+          Run multiple rollouts to see termination analysis
+        </div>
       </div>
     )
   }
 
-  // Prepare chart data
-  const terminationCountsData = (analysis.top_causes || [])
+  // Prepare data
+  const terminationData = (analysis.top_causes || [])
     .filter((item) => Array.isArray(item) && item.length >= 2)
-    .map(([reason, count], idx) => ({
-      reason:
-        (reason || 'unknown').length > 20
-          ? (reason || 'unknown').substring(0, 20) + '...'
-          : reason || 'unknown',
+    .map(([reason, count]) => ({
+      reason: (reason || 'unknown').length > 15 ? (reason || 'unknown').substring(0, 15) + '...' : reason || 'unknown',
       count: count || 0,
       fullReason: reason || 'unknown',
-      color: COLORS[idx % COLORS.length],
     }))
 
-  const heatmapData = (analysis.heatmap_data || [])
+  const stepData = (analysis.heatmap_data || [])
     .filter((item) => item && item.reason)
-    .map((item, idx) => ({
-      reason:
-        (item.reason || 'unknown').length > 20
-          ? (item.reason || 'unknown').substring(0, 20) + '...'
-          : item.reason || 'unknown',
-      meanStep: item.mean_step || 0,
-      medianStep: item.median_step || 0,
-      stdStep: item.std_step || 0,
-      minStep: item.min_step || 0,
-      maxStep: item.max_step || 0,
+    .map((item) => ({
+      reason: (item.reason || 'unknown').length > 15 ? (item.reason || 'unknown').substring(0, 15) + '...' : item.reason || 'unknown',
+      mean: item.mean_step || 0,
+      std: item.std_step || 0,
       count: item.count || 0,
-      fullReason: item.reason || 'unknown',
-      color: COLORS[idx % COLORS.length],
     }))
 
   return (
     <div className="space-y-6">
-      {/* Professional Header */}
-      <div className="flex items-center justify-between pb-3 border-b border-border">
-        <div>
-          <h3 className="text-xl font-bold text-foreground">Termination Pattern Analysis</h3>
-          <p className="text-xs text-muted-foreground mt-1">
-            Statistical analysis of episode termination causes
-          </p>
-        </div>
-        <div className="text-right">
-          <div className="text-sm font-semibold text-foreground">{rollouts.length} rollouts</div>
-          <div className="text-xs text-green-600 font-mono mt-1">✓ scipy.stats</div>
-        </div>
-      </div>
-
-      {/* Termination Counts Bar Chart - Professional */}
-      <div className="bg-card border border-border rounded-lg p-5 shadow-sm">
-        <div className="flex items-center justify-between mb-4">
-          <h4 className="text-md font-bold text-foreground">Termination Frequency Distribution</h4>
-          <span className="text-xs text-muted-foreground font-mono">Count</span>
-        </div>
-        {terminationCountsData.length > 0 ? (
-          <ResponsiveContainer width="100%" height={320}>
-            <BarChart
-              data={terminationCountsData}
-              margin={{ top: 10, right: 10, left: 10, bottom: 60 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--muted-foreground) / 0.15)" />
+      {/* Termination Frequency */}
+      <div>
+        <h4 className="text-xs font-medium mb-3">Termination Frequency</h4>
+        {terminationData.length > 0 ? (
+          <ResponsiveContainer width="100%" height={200}>
+            <BarChart data={terminationData} margin={{ top: 10, right: 20, left: 10, bottom: 40 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" opacity={0.5} />
               <XAxis
                 dataKey="reason"
                 stroke="hsl(var(--muted-foreground))"
+                fontSize={10}
                 angle={-45}
                 textAnchor="end"
-                height={80}
-                tick={{ fontSize: 11 }}
+                height={60}
+                tickLine={false}
               />
-              <YAxis
-                stroke="hsl(var(--muted-foreground))"
-                tick={{ fontSize: 11 }}
-                label={{
-                  value: 'Frequency',
-                  angle: -90,
-                  position: 'insideLeft',
-                  style: { fontSize: 12 },
-                }}
-              />
+              <YAxis stroke="hsl(var(--muted-foreground))" fontSize={11} tickLine={false} />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
+                  backgroundColor: 'hsl(var(--popover))',
                   border: '1px solid hsl(var(--border))',
                   borderRadius: '6px',
-                  boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
+                  fontSize: '12px',
                 }}
-                labelStyle={{
-                  color: 'hsl(var(--foreground))',
-                  fontWeight: 'bold',
-                  marginBottom: '4px',
-                }}
-                itemStyle={{ color: 'hsl(var(--foreground))' }}
                 formatter={(value: number) => [value, 'Episodes']}
-                labelFormatter={(label) => {
-                  const item = terminationCountsData.find((d) => d.reason === label)
-                  return item?.fullReason || label
-                }}
               />
-              <Bar dataKey="count" fill="#3b82f6" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="count" fill="#6366f1" radius={[2, 2, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         ) : (
-          <div className="h-64 flex items-center justify-center text-muted-foreground">
-            No termination data available
+          <div className="h-32 flex items-center justify-center text-muted-foreground text-xs">
+            No termination data
           </div>
         )}
       </div>
 
-      {/* Termination Step Distribution - Professional Statistical Chart */}
-      <div className="bg-card border border-border rounded-lg p-5 shadow-sm">
-        <div className="flex items-center justify-between mb-4">
-          <h4 className="text-md font-bold text-foreground">Termination Step Statistics</h4>
-          <div className="flex items-center gap-3 text-xs">
-            <div className="flex items-center gap-1">
-              <div className="w-3 h-3 rounded bg-blue-500" />
-              <span className="text-muted-foreground">Mean (tmean)</span>
-            </div>
-            <div className="flex items-center gap-1">
-              <div className="w-3 h-3 rounded bg-green-500" />
-              <span className="text-muted-foreground">Median</span>
-            </div>
-            <div className="flex items-center gap-1">
-              <div className="w-3 h-3 rounded bg-purple-500" />
-              <span className="text-muted-foreground">Std (tstd)</span>
-            </div>
-          </div>
-        </div>
-        {heatmapData.length > 0 ? (
-          <ResponsiveContainer width="100%" height={320}>
-            <BarChart data={heatmapData} margin={{ top: 10, right: 10, left: 10, bottom: 60 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--muted-foreground) / 0.15)" />
-              <XAxis
-                dataKey="reason"
-                stroke="hsl(var(--muted-foreground))"
-                angle={-45}
-                textAnchor="end"
-                height={80}
-                tick={{ fontSize: 11 }}
-              />
-              <YAxis
-                stroke="hsl(var(--muted-foreground))"
-                tick={{ fontSize: 11 }}
-                label={{
-                  value: 'Step',
-                  angle: -90,
-                  position: 'insideLeft',
-                  style: { fontSize: 12 },
-                }}
-              />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: '6px',
-                  boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
-                }}
-                labelStyle={{
-                  color: 'hsl(var(--foreground))',
-                  fontWeight: 'bold',
-                  marginBottom: '4px',
-                }}
-                itemStyle={{ color: 'hsl(var(--foreground))' }}
-                formatter={(value: number, name: string) => {
-                  if (name === 'meanStep') return [value.toFixed(1), 'Mean (scipy.stats.tmean)']
-                  if (name === 'medianStep') return [value.toFixed(1), 'Median']
-                  if (name === 'stdStep') return [value.toFixed(1), 'Std Dev (scipy.stats.tstd)']
-                  return [value, name]
-                }}
-                labelFormatter={(label) => {
-                  const item = heatmapData.find((d) => d.reason === label)
-                  return item?.fullReason || label
-                }}
-              />
-              <Bar dataKey="meanStep" fill="#3b82f6" radius={[4, 4, 0, 0]} />
-              <Bar dataKey="medianStep" fill="#10b981" radius={[4, 4, 0, 0]} opacity={0.8} />
-              <Bar dataKey="stdStep" fill="#8b5cf6" radius={[4, 4, 0, 0]} opacity={0.7} />
-            </BarChart>
-          </ResponsiveContainer>
-        ) : (
-          <div className="h-64 flex items-center justify-center text-muted-foreground">
-            No step distribution data available
-          </div>
-        )}
-      </div>
-
-      {/* Pie Chart */}
-      {terminationCountsData.length > 0 && (
-        <div className="bg-card border border-border rounded-lg p-4">
-          <h4 className="text-md font-semibold mb-4">Termination Distribution</h4>
-          <ResponsiveContainer width="100%" height={300}>
-            <PieChart>
-              <Pie
-                data={terminationCountsData}
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                label={({ reason, percent }) => `${reason}: ${(percent * 100).toFixed(0)}%`}
-                outerRadius={100}
-                fill="#8884d8"
-                dataKey="count"
-              >
-                {terminationCountsData.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={entry.color} />
+      {/* Step Statistics Table */}
+      {stepData.length > 0 && (
+        <div>
+          <h4 className="text-xs font-medium mb-3">Termination Step Statistics</h4>
+          <div className="border border-border rounded-lg overflow-hidden">
+            <table className="w-full text-xs">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="text-left px-3 py-2 font-medium">Reason</th>
+                  <th className="text-right px-3 py-2 font-medium">Count</th>
+                  <th className="text-right px-3 py-2 font-medium">Mean Step</th>
+                  <th className="text-right px-3 py-2 font-medium">Std Dev</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stepData.map((row, idx) => (
+                  <tr key={idx} className="border-t border-border">
+                    <td className="px-3 py-2">{row.reason}</td>
+                    <td className="px-3 py-2 text-right font-mono">{row.count}</td>
+                    <td className="px-3 py-2 text-right font-mono">{row.mean.toFixed(1)}</td>
+                    <td className="px-3 py-2 text-right font-mono">{row.std.toFixed(1)}</td>
+                  </tr>
                 ))}
-              </Pie>
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: 'hsl(var(--card))',
-                  border: '1px solid hsl(var(--border))',
-                }}
-                labelStyle={{ color: 'hsl(var(--foreground))' }}
-                itemStyle={{ color: 'hsl(var(--foreground))' }}
-              />
-            </PieChart>
-          </ResponsiveContainer>
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
 
-      {/* Conflicting Rules */}
-      {analysis.conflicting_rules &&
-        Array.isArray(analysis.conflicting_rules) &&
-        analysis.conflicting_rules.length > 0 && (
-          <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-md p-4">
-            <h4 className="text-sm font-semibold text-yellow-700 dark:text-yellow-400 mb-2">
-              ⚠️ Conflicting Termination Rules
-            </h4>
-            <div className="space-y-2">
-              {analysis.conflicting_rules
-                .filter((conflict) => conflict && conflict.rule)
-                .map((conflict, idx) => (
-                  <div key={idx} className="text-sm">
-                    <div className="font-medium">{conflict.rule}</div>
-                    <div className="text-muted-foreground">
-                      Frequency: {((conflict.frequency || 0) * 100).toFixed(1)}% | Conflicts with:{' '}
-                      {(conflict.conflict_with || []).join(', ')}
-                    </div>
-                  </div>
-                ))}
-            </div>
-          </div>
-        )}
-
-      {/* Premature Terminations */}
-      {analysis.premature_terminations &&
-        Array.isArray(analysis.premature_terminations) &&
-        analysis.premature_terminations.length > 0 && (
-          <div className="bg-orange-500/10 border border-orange-500/20 rounded-md p-4">
-            <h4 className="text-sm font-semibold text-orange-700 dark:text-orange-400 mb-2">
-              ⚠️ Premature Terminations (scipy.stats.percentile)
-            </h4>
-            <div className="space-y-2">
-              {analysis.premature_terminations
-                .filter((premature) => premature && premature.reason)
-                .map((premature, idx) => (
-                  <div key={idx} className="text-sm">
-                    <div className="font-medium">{premature.reason}</div>
-                    <div className="text-muted-foreground">
-                      {premature.count || 0} episodes | Mean step:{' '}
-                      {(premature.mean_step || 0).toFixed(1)} | Threshold:{' '}
-                      {(premature.threshold || 0).toFixed(1)}
-                    </div>
-                  </div>
-                ))}
-            </div>
-          </div>
-        )}
+      {/* Warnings */}
+      {analysis.premature_terminations && analysis.premature_terminations.length > 0 && (
+        <div className="text-xs text-amber-600">
+          ⚠ {analysis.premature_terminations.length} premature termination(s) detected
+        </div>
+      )}
     </div>
   )
 }

--- a/app/components/ValidationPanel.tsx
+++ b/app/components/ValidationPanel.tsx
@@ -1,0 +1,72 @@
+/**
+ * Validation Panel - Shows errors, warnings, and suggestions for action space configuration
+ */
+
+import { ActionSpaceValidation } from '~/lib/actionSpaceValidation'
+
+interface ValidationPanelProps {
+  validation: ActionSpaceValidation
+  title?: string
+}
+
+export function ValidationPanel({ validation, title = 'Configuration Status' }: ValidationPanelProps) {
+  if (validation.valid && validation.warnings.length === 0 && validation.errors.length === 0) {
+    return (
+      <div className="bg-green-500/10 border border-green-500/20 rounded-lg p-3">
+        <div className="flex items-center gap-2">
+          <span className="text-green-600 dark:text-green-400 text-lg">✅</span>
+          <span className="text-sm font-medium text-green-700 dark:text-green-300">
+            {title}: Valid configuration
+          </span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {validation.errors.length > 0 && (
+        <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-red-600 dark:text-red-400 text-lg">❌</span>
+            <span className="text-sm font-medium text-red-700 dark:text-red-300">Errors</span>
+          </div>
+          <ul className="text-xs text-red-600 dark:text-red-400 space-y-1 ml-6 list-disc">
+            {validation.errors.map((error, i) => (
+              <li key={i}>{error}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {validation.warnings.length > 0 && (
+        <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-yellow-600 dark:text-yellow-400 text-lg">⚠️</span>
+            <span className="text-sm font-medium text-yellow-700 dark:text-yellow-300">Warnings</span>
+          </div>
+          <ul className="text-xs text-yellow-600 dark:text-yellow-400 space-y-1 ml-6 list-disc">
+            {validation.warnings.map((warning, i) => (
+              <li key={i}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {validation.suggestions.length > 0 && (
+        <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-blue-600 dark:text-blue-400 text-lg">💡</span>
+            <span className="text-sm font-medium text-blue-700 dark:text-blue-300">Suggestions</span>
+          </div>
+          <ul className="text-xs text-blue-600 dark:text-blue-400 space-y-1 ml-6 list-disc">
+            {validation.suggestions.map((suggestion, i) => (
+              <li key={i}>{suggestion}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/app/lib/actionSpaceValidation.ts
+++ b/app/lib/actionSpaceValidation.ts
@@ -1,0 +1,238 @@
+/**
+ * Action Space Validation Utilities
+ * Validates action space configurations and compatibility with environment types and dynamics
+ */
+
+import { ActionSpaceSpec, DynamicsSpec, EnvType } from './envSpec'
+
+export interface ActionSpaceValidation {
+  valid: boolean
+  errors: string[]
+  warnings: string[]
+  suggestions: string[]
+}
+
+/**
+ * Validate action space configuration
+ */
+export function validateActionSpace(
+  actionSpace: ActionSpaceSpec | undefined,
+  envType: EnvType,
+  dynamics?: DynamicsSpec
+): ActionSpaceValidation {
+  const errors: string[] = []
+  const warnings: string[] = []
+  const suggestions: string[] = []
+
+  // Check if action space exists
+  if (!actionSpace) {
+    errors.push('Action space is required')
+    return { valid: false, errors, warnings, suggestions }
+  }
+
+  // Validate discrete action space
+  if (actionSpace.type === 'discrete') {
+    // Check actions array
+    if (!Array.isArray(actionSpace.actions)) {
+      errors.push('Discrete action space must have an actions array')
+    } else if (actionSpace.actions.length === 0) {
+      errors.push('At least one action is required')
+    } else if (actionSpace.actions.length < 2) {
+      warnings.push('Consider having at least 2 actions for meaningful control')
+    }
+
+    // Check for duplicate actions
+    const duplicates = actionSpace.actions.filter(
+      (action, index) => actionSpace.actions.indexOf(action) !== index
+    )
+    if (duplicates.length > 0) {
+      errors.push(`Duplicate action names: ${[...new Set(duplicates)].join(', ')}`)
+    }
+
+    // Check for empty action names
+    const emptyActions = actionSpace.actions.filter((action) => !action || action.trim() === '')
+    if (emptyActions.length > 0) {
+      errors.push('Action names cannot be empty')
+    }
+
+    // Check for invalid action names (spaces, special chars)
+    const invalidActions = actionSpace.actions.filter(
+      (action) => action && !/^[a-zA-Z0-9_]+$/.test(action)
+    )
+    if (invalidActions.length > 0) {
+      errors.push(
+        `Invalid action names (use letters, numbers, underscores only): ${invalidActions.join(', ')}`
+      )
+      suggestions.push('Use snake_case: e.g., "move_up" instead of "move up"')
+    }
+
+    // Environment compatibility
+    if (envType === 'continuous2d') {
+      warnings.push('Discrete actions in continuous environment - consider using continuous actions')
+      suggestions.push('For continuous environments, continuous actions provide smoother control')
+    }
+
+    // Dynamics compatibility
+    if (dynamics?.type === 'continuous-velocity') {
+      warnings.push('Discrete actions with continuous velocity dynamics may be suboptimal')
+      suggestions.push('Consider using continuous actions or grid-step dynamics')
+    }
+  }
+
+  // Validate continuous action space
+  if (actionSpace.type === 'continuous') {
+    // Check dimensions
+    if (typeof actionSpace.dimensions !== 'number') {
+      errors.push('Continuous action space must have numeric dimensions')
+    } else if (actionSpace.dimensions <= 0) {
+      errors.push('Dimensions must be a positive integer')
+    } else if (!Number.isInteger(actionSpace.dimensions)) {
+      errors.push('Dimensions must be an integer')
+    } else if (actionSpace.dimensions < 2 && envType === 'continuous2d') {
+      warnings.push('For 2D environments, consider using 2 dimensions (X, Y velocity)')
+    } else if (actionSpace.dimensions > 4) {
+      warnings.push('High-dimensional action spaces may be harder to train')
+    }
+
+    // Check range
+    if (!Array.isArray(actionSpace.range) || actionSpace.range.length !== 2) {
+      errors.push('Continuous action space must have range [min, max]')
+    } else {
+      const [min, max] = actionSpace.range
+      if (typeof min !== 'number' || typeof max !== 'number') {
+        errors.push('Range values must be numbers')
+      } else if (!isFinite(min) || !isFinite(max)) {
+        errors.push('Range values must be finite numbers')
+      } else if (min >= max) {
+        errors.push('Range min must be less than max')
+      } else if (Math.abs(min) > 10 || Math.abs(max) > 10) {
+        warnings.push('Large action ranges may cause instability - consider normalizing to [-1, 1]')
+      }
+    }
+
+    // Environment compatibility
+    if (envType === 'grid') {
+      warnings.push('Continuous actions in grid environment - consider using discrete actions')
+      suggestions.push('Grid environments typically work better with discrete actions')
+    }
+
+    // Dynamics compatibility
+    if (dynamics?.type === 'grid-step') {
+      warnings.push('Continuous actions with grid-step dynamics may cause issues')
+      suggestions.push('Consider using discrete actions or continuous-velocity dynamics')
+    }
+  }
+
+  // General compatibility checks
+  if (envType === 'grid' && actionSpace.type === 'continuous' && dynamics?.type === 'grid-step') {
+    warnings.push('Mismatch: Continuous actions with grid-step dynamics')
+    suggestions.push('For grid environments, use discrete actions with grid-step dynamics')
+  }
+
+  if (
+    envType === 'continuous2d' &&
+    actionSpace.type === 'discrete' &&
+    dynamics?.type === 'continuous-velocity'
+  ) {
+    warnings.push('Mismatch: Discrete actions with continuous velocity dynamics')
+    suggestions.push('For continuous environments, use continuous actions with continuous-velocity dynamics')
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    suggestions,
+  }
+}
+
+/**
+ * Validate dynamics configuration
+ */
+export function validateDynamics(
+  dynamics: DynamicsSpec | undefined,
+  actionSpace?: ActionSpaceSpec
+): ActionSpaceValidation {
+  const errors: string[] = []
+  const warnings: string[] = []
+  const suggestions: string[] = []
+
+  if (!dynamics) {
+    errors.push('Dynamics configuration is required')
+    return { valid: false, errors, warnings, suggestions }
+  }
+
+  if (dynamics.type === 'continuous-velocity') {
+    if (typeof dynamics.maxSpeed !== 'number') {
+      errors.push('Max speed must be a number')
+    } else if (dynamics.maxSpeed <= 0) {
+      errors.push('Max speed must be positive')
+    } else if (dynamics.maxSpeed > 10) {
+      warnings.push('Very high max speed may cause instability')
+    }
+  }
+
+  if (dynamics.type === 'car-like') {
+    if (typeof dynamics.maxSpeed !== 'number' || dynamics.maxSpeed <= 0) {
+      errors.push('Max speed must be a positive number')
+    }
+    if (typeof dynamics.turnRate !== 'number' || dynamics.turnRate <= 0) {
+      errors.push('Turn rate must be a positive number')
+    }
+  }
+
+  // Compatibility with action space
+  if (actionSpace) {
+    if (actionSpace.type === 'discrete' && dynamics.type === 'continuous-velocity') {
+      warnings.push('Discrete actions with continuous velocity - consider continuous actions')
+    }
+    if (actionSpace.type === 'continuous' && dynamics.type === 'grid-step') {
+      warnings.push('Continuous actions with grid-step - consider discrete actions or continuous-velocity')
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    suggestions,
+  }
+}
+
+/**
+ * Get recommended action space for environment type
+ */
+export function getRecommendedActionSpace(envType: EnvType): ActionSpaceSpec {
+  if (envType === 'grid') {
+    return {
+      type: 'discrete',
+      actions: ['up', 'down', 'left', 'right'],
+    }
+  } else if (envType === 'continuous2d') {
+    return {
+      type: 'continuous',
+      dimensions: 2,
+      range: [-1, 1],
+    }
+  } else {
+    // Default to discrete
+    return {
+      type: 'discrete',
+      actions: ['up', 'down', 'left', 'right'],
+    }
+  }
+}
+
+/**
+ * Get recommended dynamics for environment type
+ */
+export function getRecommendedDynamics(envType: EnvType): DynamicsSpec {
+  if (envType === 'grid') {
+    return { type: 'grid-step' }
+  } else if (envType === 'continuous2d') {
+    return { type: 'continuous-velocity', maxSpeed: 0.1 }
+  } else {
+    return { type: 'grid-step' }
+  }
+}
+

--- a/app/lib/envSpec.ts
+++ b/app/lib/envSpec.ts
@@ -105,6 +105,10 @@ export type ConditionSpec =
   | { type: 'collision'; a: string; b: string }
   | { type: 'timeout'; steps: number }
   | { type: 'inside_region'; agentId: string; regionId: string }
+  | { type: 'step' }
+  | { type: 'reach_goal' }
+  | { type: 'hit_trap' }
+  | { type: 'collect_key' }
   | { type: 'custom'; script: string }
 
 export type RewardRule = {

--- a/backend/rl_studio/rollout/simulator.py
+++ b/backend/rl_studio/rollout/simulator.py
@@ -69,6 +69,71 @@ def evaluate_condition(
     elif cond_type == "timeout":
         return True
 
+    elif cond_type == "step":
+        # Per-step reward - always true (triggers every step)
+        return True
+
+    elif cond_type == "reach_goal":
+        # Check if agent is at any goal object
+        if not state.get("agents") or len(state["agents"]) == 0:
+            return False
+        agent = state["agents"][0]
+        agent_pos_list = agent.get("position", [0, 0])
+        if not isinstance(agent_pos_list, list) or len(agent_pos_list) < 2:
+            return False
+        agent_pos = Vec2.from_list(agent_pos_list)
+
+        # Find goals from env_spec (source of truth)
+        goals = [obj for obj in env_spec.get("objects", []) if obj.get("type") == "goal"]
+        for goal in goals:
+            goal_pos_list = goal.get("position", [0, 0])
+            if isinstance(goal_pos_list, list) and len(goal_pos_list) >= 2:
+                goal_pos = Vec2.from_list(goal_pos_list)
+                distance = agent_pos.distance(goal_pos)
+                if distance <= 0.5:
+                    return True
+        return False
+
+    elif cond_type == "hit_trap":
+        # Check if agent is at any trap object
+        if not state.get("agents") or len(state["agents"]) == 0:
+            return False
+        agent = state["agents"][0]
+        agent_pos_list = agent.get("position", [0, 0])
+        if not isinstance(agent_pos_list, list) or len(agent_pos_list) < 2:
+            return False
+        agent_pos = Vec2.from_list(agent_pos_list)
+
+        traps = [obj for obj in env_spec.get("objects", []) if obj.get("type") == "trap"]
+        for trap in traps:
+            trap_pos_list = trap.get("position", [0, 0])
+            if isinstance(trap_pos_list, list) and len(trap_pos_list) >= 2:
+                trap_pos = Vec2.from_list(trap_pos_list)
+                distance = agent_pos.distance(trap_pos)
+                if distance <= 0.5:
+                    return True
+        return False
+
+    elif cond_type == "collect_key":
+        # Check if agent is at any key object
+        if not state.get("agents") or len(state["agents"]) == 0:
+            return False
+        agent = state["agents"][0]
+        agent_pos_list = agent.get("position", [0, 0])
+        if not isinstance(agent_pos_list, list) or len(agent_pos_list) < 2:
+            return False
+        agent_pos = Vec2.from_list(agent_pos_list)
+
+        keys = [obj for obj in env_spec.get("objects", []) if obj.get("type") == "key"]
+        for key in keys:
+            key_pos_list = key.get("position", [0, 0])
+            if isinstance(key_pos_list, list) and len(key_pos_list) >= 2:
+                key_pos = Vec2.from_list(key_pos_list)
+                distance = agent_pos.distance(key_pos)
+                if distance <= 0.5:
+                    return True
+        return False
+
     elif cond_type == "collision":
         agent_id = condition.get("agentId")
         agent = next((a for a in state["agents"] if a.get("id") == agent_id), None)

--- a/backend/rl_studio/utils/rollout_storage.py
+++ b/backend/rl_studio/utils/rollout_storage.py
@@ -1,0 +1,207 @@
+"""
+Rollout Storage Utility
+Saves and loads rollout data to/from S3
+Uses credentials from .env file, NOT default AWS profile
+"""
+
+import gzip
+import json
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+# Load .env file before importing other modules
+try:
+    from dotenv import load_dotenv
+    
+    env_paths = [
+        Path(__file__).parent.parent.parent / ".env",  # backend/.env
+        Path(__file__).parent.parent.parent.parent / ".env",  # root/.env
+        Path(__file__).parent.parent.parent / "tokens" / "prod.txt",
+        Path(__file__).parent.parent.parent / "tokens" / "dev.txt",
+    ]
+    
+    for env_path in env_paths:
+        if env_path.exists():
+            load_dotenv(env_path, override=True)
+            break
+except ImportError:
+    pass
+
+from .infrastructure_config import get_infrastructure_config
+from .storage import get_storage_client
+
+logger = logging.getLogger(__name__)
+
+
+def save_rollout_to_s3(
+    rollout_data: Dict[str, Any], env_id: str, rollout_id: Optional[str] = None
+) -> str:
+    """
+    Save rollout data to S3 with compression.
+
+    Args:
+        rollout_data: Full rollout data (SimulatorResult)
+        env_id: Environment ID
+        rollout_id: Optional rollout ID (generated if not provided)
+
+    Returns:
+        S3 URL (s3://bucket/key)
+    """
+    if not rollout_id:
+        rollout_id = str(uuid.uuid4())
+
+    config = get_infrastructure_config()
+    storage_config = config.get_storage_config()
+    provider = storage_config["provider"]
+
+    if provider != "s3":
+        raise ValueError(
+            f"Rollout storage requires S3. Current provider: {provider}"
+        )
+
+    bucket_name = storage_config.get("bucket_name")
+    if not bucket_name:
+        raise ValueError(
+            "S3_BUCKET_NAME or MODEL_BUCKET_NAME must be set in environment"
+        )
+
+    # Compress rollout data
+    rollout_json = json.dumps(rollout_data, default=str)
+    compressed_data = gzip.compress(rollout_json.encode("utf-8"))
+
+    # S3 key: rollouts/{env_id}/{rollout_id}.json.gz
+    s3_key = f"rollouts/{env_id}/{rollout_id}.json.gz"
+
+    try:
+        client, provider = get_storage_client()
+
+        # Upload to S3
+        if provider == "s3":
+            # boto3.client is a function, not a type - check provider instead
+            client.put_object(
+                Bucket=bucket_name,
+                Key=s3_key,
+                Body=compressed_data,
+                ContentType="application/json",
+                ContentEncoding="gzip",
+                Metadata={
+                    "env_id": env_id,
+                    "rollout_id": rollout_id,
+                    "episode_length": str(rollout_data.get("episodeLength", 0)),
+                    "total_reward": str(rollout_data.get("totalReward", 0)),
+                },
+            )
+            s3_url = f"s3://{bucket_name}/{s3_key}"
+            logger.info(f"✅ Saved rollout to S3: {s3_url}")
+            return s3_url
+        else:
+            raise ValueError(f"S3 client not properly initialized. Provider: {provider}")
+    except Exception as e:
+        logger.error(f"Failed to save rollout to S3: {e}")
+        raise
+
+
+def load_rollout_from_s3(s3_url: str) -> Dict[str, Any]:
+    """
+    Load rollout data from S3.
+
+    Args:
+        s3_url: S3 URL (s3://bucket/key)
+
+    Returns:
+        Full rollout data (SimulatorResult)
+    """
+    if not s3_url.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URL: {s3_url}")
+
+    # Parse s3://bucket/key
+    parts = s3_url.replace("s3://", "").split("/", 1)
+    bucket_name = parts[0]
+    s3_key = parts[1] if len(parts) > 1 else ""
+
+    try:
+        client, provider = get_storage_client()
+
+        if provider == "s3":
+            # Download from S3
+            response = client.get_object(Bucket=bucket_name, Key=s3_key)
+            compressed_data = response["Body"].read()
+
+            # Decompress
+            decompressed_data = gzip.decompress(compressed_data)
+            rollout_data = json.loads(decompressed_data.decode("utf-8"))
+
+            logger.info(f"✅ Loaded rollout from S3: {s3_url}")
+            return rollout_data
+        else:
+            raise ValueError(f"S3 client not properly initialized. Provider: {provider}")
+    except Exception as e:
+        logger.error(f"Failed to load rollout from S3: {e}")
+        raise
+
+
+def delete_rollout_from_s3(s3_url: str) -> bool:
+    """
+    Delete rollout data from S3.
+
+    Args:
+        s3_url: S3 URL (s3://bucket/key)
+
+    Returns:
+        True if successful
+    """
+    if not s3_url.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URL: {s3_url}")
+
+    # Parse s3://bucket/key
+    parts = s3_url.replace("s3://", "").split("/", 1)
+    bucket_name = parts[0]
+    s3_key = parts[1] if len(parts) > 1 else ""
+
+    try:
+        client, provider = get_storage_client()
+
+        if provider == "s3":
+            client.delete_object(Bucket=bucket_name, Key=s3_key)
+            logger.info(f"✅ Deleted rollout from S3: {s3_url}")
+            return True
+        else:
+            raise ValueError(f"S3 client not properly initialized. Provider: {provider}")
+    except Exception as e:
+        logger.error(f"Failed to delete rollout from S3: {e}")
+        return False
+
+
+def get_rollout_size(s3_url: str) -> int:
+    """
+    Get size of rollout file in S3 (in bytes).
+
+    Args:
+        s3_url: S3 URL (s3://bucket/key)
+
+    Returns:
+        Size in bytes
+    """
+    if not s3_url.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URL: {s3_url}")
+
+    # Parse s3://bucket/key
+    parts = s3_url.replace("s3://", "").split("/", 1)
+    bucket_name = parts[0]
+    s3_key = parts[1] if len(parts) > 1 else ""
+
+    try:
+        client, provider = get_storage_client()
+
+        if provider == "s3":
+            response = client.head_object(Bucket=bucket_name, Key=s3_key)
+            return response.get("ContentLength", 0)
+        else:
+            raise ValueError(f"S3 client not properly initialized. Provider: {provider}")
+    except Exception as e:
+        logger.error(f"Failed to get rollout size: {e}")
+        return 0
+

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,93 @@
+# RL Studio Infrastructure
+
+This directory contains documentation for RL Studio's AWS infrastructure.
+
+## 🚀 S3 Bucket Setup
+
+S3 bucket setup is handled directly in the backend code using `rl_studio.utils.s3_bucket_setup`.
+
+The bucket is created automatically when needed, or can be set up manually using the backend utilities.
+
+## ⚠️ IMPORTANT: Uses Credentials from .env
+
+**All infrastructure scripts use credentials from `.env` file, NOT your default AWS profile.**
+
+The scripts will:
+1. Load credentials from `backend/.env` or `backend/tokens/prod.txt` or `backend/tokens/dev.txt`
+2. Use those credentials explicitly (not default AWS profile)
+3. Create resources in the AWS account associated with those credentials
+
+## Prerequisites
+
+1. **AWS Credentials in .env file**
+   - Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in `backend/.env`
+   - Or in `backend/tokens/prod.txt` or `backend/tokens/dev.txt`
+   - Set `AWS_DEFAULT_REGION` (default: `us-east-1`)
+   - Set `S3_BUCKET_NAME` (default: `rl-studio-rollouts`)
+
+## What Gets Created
+
+- **S3 Bucket**: `rl-studio-rollouts` (or your custom name)
+  - Versioning enabled
+  - Server-side encryption (AES256)
+  - Public access blocked
+  - Lifecycle policy (auto-delete after 365 days)
+
+- **IAM User**: `rl-studio-rollouts-service-user`
+  - Policy attached for S3 bucket access
+  - Access keys for backend service
+
+- **IAM Policy**: Allows:
+  - `s3:GetObject` - Read rollouts
+  - `s3:PutObject` - Save rollouts
+  - `s3:DeleteObject` - Delete rollouts
+  - `s3:ListBucket` - List rollouts
+
+## Configuration
+
+Set in `backend/.env`:
+
+```bash
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+AWS_DEFAULT_REGION=us-east-1
+S3_BUCKET_NAME=rl-studio-rollouts
+```
+
+## Security Notes
+
+1. **IAM Credentials**: The IAM user access key is only shown once. Save it securely!
+2. **Bucket Policy**: Only authenticated users with the IAM policy can access the bucket
+3. **Public Access**: All public access is blocked
+4. **Encryption**: All data is encrypted at rest (AES256)
+5. **Credentials**: Uses `.env` file credentials, NOT default AWS profile
+
+## Troubleshooting
+
+### Bucket already exists
+The script will detect if the bucket already exists and skip creation.
+
+### Permission denied
+Ensure your AWS credentials in `.env` have:
+- `s3:CreateBucket`
+- `s3:PutBucketVersioning`
+- `s3:PutBucketEncryption`
+- `s3:PutBucketPublicAccessBlock`
+- `s3:PutBucketLifecycleConfiguration`
+- `iam:CreateUser`
+- `iam:PutUserPolicy`
+- `iam:CreateAccessKey`
+
+### Wrong AWS account
+**Make sure your `.env` file has the correct AWS credentials!**
+The scripts use credentials from `.env`, not your default AWS profile.
+
+### Region mismatch
+Ensure `AWS_DEFAULT_REGION` in `.env` matches your credentials region.
+Default: `us-east-1`
+
+## Backend Utilities
+
+S3 bucket creation is handled by `backend/rl_studio/utils/s3_bucket_setup.py`:
+- `create_rollout_bucket()` - Creates S3 bucket and IAM resources
+- `verify_bucket_access()` - Verifies bucket access with current credentials


### PR DESCRIPTION
## Changes

- ✅ Add ability to view previous rollouts from history
- ✅ Implement S3 storage for full rollout data
- ✅ Add in-memory cache for recent rollouts (last 10)
- ✅ Add backend endpoint to load rollouts from S3
- ✅ Improve RL Analysis tab with better data visualization
- ✅ Fix reward calculation in backend simulator (reach_goal, step, hit_trap, collect_key conditions)
- ✅ Add validation for action space and dynamics
- ✅ Clean up unnecessary files (dev.txt, prod.txt, check_aws_account.py, s3_bucket_setup.py)
- ✅ Update .gitignore to exclude token files

## Technical Details

- Historical rollouts are saved with summary data to Convex (to avoid 1MB limit)
- Full rollout data is stored in S3 with compression
- When clicking a history item, the system:
  1. Checks in-memory cache first (fastest)
  2. Falls back to loading from S3 if available
  3. Shows helpful error if data is unavailable

- All tabs (Reward Inspector, Event Log, RL Analysis) automatically use the selected rollout
- New rollouts automatically clear history selection and switch to new data